### PR TITLE
Implement simple allocator, with small testing suite.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -19,4 +19,8 @@ go_test(
     name = "allocator_test",
     srcs = ["allocator_test.go"],
     embed = [":allocator"],
+    deps = [
+        "@com_github_irfansharif_or_tools//cpsatsolver",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/allocator.go
+++ b/allocator.go
@@ -58,6 +58,6 @@ func addAssignToSomeNodeConstraint(model *cpsatsolver.Model, assignment [][]cpsa
 		// constraint each range to exist on exactly one node.
 		model.AddConstraints(
 			cpsatsolver.NewLinearConstraint(cpsatsolver.NewLinearExpr(assignment[_rangeIndex], coefficients, 0),
-			cpsatsolver.NewDomain(1, 1)))
+				cpsatsolver.NewDomain(1, 1)))
 	}
 }

--- a/allocator.go
+++ b/allocator.go
@@ -1,1 +1,63 @@
 package allocator
+
+import (
+	"fmt"
+	"github.com/irfansharif/or-tools/cpsatsolver"
+)
+
+type node struct {
+	tag int64
+}
+
+type _range struct {
+	tag int64
+}
+
+const ClusterSize = 64
+
+func allocate(ranges []_range) [][]int {
+	// basic allocator, given ranges, assign
+	// all ranges to some node.
+	model := cpsatsolver.NewModel()
+	// assignment matrix, [i][j] == 1 means
+	// range i was deployed onto node j
+	assignment := make([][]cpsatsolver.IntVar, len(ranges))
+	// this is our return matrix, init'zed here for visibility
+	// and separation from or-tools logic.
+	allocatedAssignments := make([][]int, len(ranges))
+	for index := range assignment {
+		assignment[index] = make([]cpsatsolver.IntVar, ClusterSize)
+	}
+	for index := range allocatedAssignments {
+		allocatedAssignments[index] = make([]int, ClusterSize)
+	}
+
+	addAssignToSomeNodeConstraint(model, assignment)
+	result := model.Solve()
+	for _rangeIndex, _range := range assignment {
+		for _assignmentIndex := range _range {
+			allocatedAssignments[_rangeIndex][_assignmentIndex] = int(result.Value(assignment[_rangeIndex][_assignmentIndex]))
+		}
+	}
+	return allocatedAssignments
+}
+
+func addAssignToSomeNodeConstraint(model *cpsatsolver.Model, assignment [][]cpsatsolver.IntVar) {
+	// used to build the linearExpression that we need to constrain
+	// each range being assigned to one and only one node.
+	coefficients := make([]int64, len(assignment[0]))
+	for index := range coefficients {
+		coefficients[index] = 1
+	}
+	for _rangeIndex := 0; _rangeIndex < len(assignment); _rangeIndex++ {
+		for nodeIndex := 0; nodeIndex < len(assignment[_rangeIndex]); nodeIndex++ {
+			// let each entry in the assignment matrix be a boolean literal, indicating presence of a
+			// range on a specified node or the inverse.
+			assignment[_rangeIndex][nodeIndex] = model.NewIntVar(0, 1, fmt.Sprintf("Assignment for range %d to node %d", _rangeIndex, nodeIndex))
+		}
+		// constraint each range to exist on exactly one node.
+		model.AddConstraints(
+			cpsatsolver.NewLinearConstraint(cpsatsolver.NewLinearExpr(assignment[_rangeIndex], coefficients, 0),
+			cpsatsolver.NewDomain(1, 1)))
+	}
+}

--- a/allocator_test.go
+++ b/allocator_test.go
@@ -1,6 +1,7 @@
 package allocator
 
 import (
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/irfansharif/or-tools/cpsatsolver"
@@ -8,4 +9,20 @@ import (
 
 func TestLibraryImport(t *testing.T) {
 	var _ cpsatsolver.Model
+}
+
+func TestAllocationForThreeRanges(t *testing.T) {
+	ranges := [3]_range{{tag: 0}, {tag: 1}, {tag: 1 << 1}}
+	allocations := allocate(ranges[0:2])
+	// assert that row holds a sum of exactly one,
+	// the allocator returns an a two dimensional array of assignments,
+	// [i][j] --> replica i assigned to node j, hence assert for each row
+	// that there exists one and only one value equal to unity.
+	for replicaCount := 0; replicaCount < len(allocations); replicaCount++ {
+		sum := 0
+		for nodeCount := 0; nodeCount < len(allocations[replicaCount]); nodeCount++ {
+			sum += allocations[replicaCount][nodeCount]
+		}
+		require.Equal(t, 1, sum)
+	}
 }


### PR DESCRIPTION
PR to add a skeleton allocator, capable of assigning **a** range to **some** node. 
Currently no checks built around the `.solve` call, will add them in the subsequent PR's.