### PR TITLE
[August-Milestone #1] Add replication, constraint to distribute replicas onto different nodes.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -9,7 +9,7 @@ gazelle(
 
 go_library(
     name = "allocator",
-    srcs = ["allocator.go"],
+    srcs = ["allocator.go", "config.go"],
     importpath = "github.com/irfansharif/allocator",
     visibility = ["//visibility:public"],
     deps = ["@com_github_irfansharif_or_tools//cpsatsolver"],

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -47,7 +47,7 @@ http_archive(
 
 git_repository(
     name = "com_github_irfansharif_or_tools",
-    commit = "3e554e075f6674a4e9956969afa3ac88b8964a3a",
+    commit = "7bf371607f5d0ace5df1eb502182d1b0aeede3e0",
     remote = "https://github.com/irfansharif/or-tools",
 )
 

--- a/allocator.go
+++ b/allocator.go
@@ -5,59 +5,44 @@ import (
 	"github.com/irfansharif/or-tools/cpsatsolver"
 )
 
-type node struct {
-	tag int64
-}
-
 type _range struct {
 	tag int64
 }
 
-const ClusterSize = 64
-
 func allocate(ranges []_range) [][]int {
-	// basic allocator, given ranges, assign
-	// all ranges to some node.
 	model := cpsatsolver.NewModel()
-	// assignment matrix, [i][j] == 1 means
-	// range i was deployed onto node j
-	assignment := make([][]cpsatsolver.IntVar, len(ranges))
-	// this is our return matrix, init'zed here for visibility
-	// and separation from or-tools logic.
-	allocatedAssignments := make([][]int, len(ranges))
-	for index := range assignment {
-		assignment[index] = make([]cpsatsolver.IntVar, ClusterSize)
+	assignment := initAssignmentMatrix(model, ranges)
+	addAssignToSomeNodeConstraint(model, assignment)
+	return constructResult(model, assignment)
+}
+
+func initAssignmentMatrix(model *cpsatsolver.Model, ranges []_range) [][]cpsatsolver.Literal {
+	assignment := make([][]cpsatsolver.Literal, len(ranges))
+	for _rangeIndex := range assignment {
+		assignment[_rangeIndex] = make([]cpsatsolver.Literal, ClusterSize)
+		for nodeIndex := 0; nodeIndex < len(assignment[_rangeIndex]); nodeIndex++ {
+			// let each entry in the assignment matrix be a boolean literal, indicating presence of a
+			// replica on a specified node or the inverse.
+			assignment[_rangeIndex][nodeIndex] = model.NewLiteral(fmt.Sprintf("Assignment for range %d to node %d", _rangeIndex, nodeIndex))
+		}
 	}
+	return assignment
+}
+
+func addAssignToSomeNodeConstraint(model *cpsatsolver.Model, assignment [][]cpsatsolver.Literal) {
+	for _rangeIndex := 0; _rangeIndex < len(assignment); _rangeIndex++ {
+		model.AddConstraints(cpsatsolver.NewExactlyKConstraint(ReplicationFactor, assignment[_rangeIndex]...))
+	}
+}
+
+func constructResult(model *cpsatsolver.Model, assignment [][]cpsatsolver.Literal) [][]int {
+	result := model.Solve()
+	allocatedAssignments := make([][]int, len(assignment))
 	for index := range allocatedAssignments {
 		allocatedAssignments[index] = make([]int, ClusterSize)
-	}
-
-	addAssignToSomeNodeConstraint(model, assignment)
-	result := model.Solve()
-	for _rangeIndex, _range := range assignment {
-		for _assignmentIndex := range _range {
-			allocatedAssignments[_rangeIndex][_assignmentIndex] = int(result.Value(assignment[_rangeIndex][_assignmentIndex]))
+		for _assignmentIndex := range allocatedAssignments[index] {
+			allocatedAssignments[index][_assignmentIndex] = int(result.Value(assignment[index][_assignmentIndex]))
 		}
 	}
 	return allocatedAssignments
-}
-
-func addAssignToSomeNodeConstraint(model *cpsatsolver.Model, assignment [][]cpsatsolver.IntVar) {
-	// used to build the linearExpression that we need to constrain
-	// each range being assigned to one and only one node.
-	coefficients := make([]int64, len(assignment[0]))
-	for index := range coefficients {
-		coefficients[index] = 1
-	}
-	for _rangeIndex := 0; _rangeIndex < len(assignment); _rangeIndex++ {
-		for nodeIndex := 0; nodeIndex < len(assignment[_rangeIndex]); nodeIndex++ {
-			// let each entry in the assignment matrix be a boolean literal, indicating presence of a
-			// range on a specified node or the inverse.
-			assignment[_rangeIndex][nodeIndex] = model.NewIntVar(0, 1, fmt.Sprintf("Assignment for range %d to node %d", _rangeIndex, nodeIndex))
-		}
-		// constraint each range to exist on exactly one node.
-		model.AddConstraints(
-			cpsatsolver.NewLinearConstraint(cpsatsolver.NewLinearExpr(assignment[_rangeIndex], coefficients, 0),
-				cpsatsolver.NewDomain(1, 1)))
-	}
 }

--- a/allocator_test.go
+++ b/allocator_test.go
@@ -1,10 +1,9 @@
 package allocator
 
 import (
+	"github.com/irfansharif/or-tools/cpsatsolver"
 	"github.com/stretchr/testify/require"
 	"testing"
-
-	"github.com/irfansharif/or-tools/cpsatsolver"
 )
 
 func TestLibraryImport(t *testing.T) {
@@ -14,15 +13,12 @@ func TestLibraryImport(t *testing.T) {
 func TestAllocationForThreeRanges(t *testing.T) {
 	ranges := [3]_range{{tag: 0}, {tag: 1}, {tag: 1 << 1}}
 	allocations := allocate(ranges[0:2])
-	// assert that row holds a sum of exactly one,
-	// the allocator returns an a two dimensional array of assignments,
-	// [i][j] --> replica i assigned to node j, hence assert for each row
-	// that there exists one and only one value equal to unity.
 	for replicaCount := 0; replicaCount < len(allocations); replicaCount++ {
 		sum := 0
 		for nodeCount := 0; nodeCount < len(allocations[replicaCount]); nodeCount++ {
 			sum += allocations[replicaCount][nodeCount]
+			require.LessOrEqual(t, allocations[replicaCount][nodeCount], 1)
 		}
-		require.Equal(t, 1, sum)
+		require.Equal(t, sum, ReplicationFactor)
 	}
 }

--- a/config.go
+++ b/config.go
@@ -1,0 +1,6 @@
+package allocator
+
+const (
+	ClusterSize       = 64
+	ReplicationFactor = 3
+)

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/irfansharif/allocator
 
 go 1.16
 
-require github.com/irfansharif/or-tools v0.0.0-20210804142827-3e554e075f66
+require (
+	github.com/irfansharif/or-tools v0.0.0-20210806150710-7bf371607f5d
+	github.com/stretchr/testify v1.7.0
+)

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/irfansharif/or-tools v0.0.0-20210804142827-3e554e075f66 h1:tn//9XksOM0lYUCvb+toY4VBr6xdovcPzz6m1HOeYEg=
-github.com/irfansharif/or-tools v0.0.0-20210804142827-3e554e075f66/go.mod h1:R/dumbSyTGDtltABqk8bHM3YHisdUCW46mEc1eSqCkY=
+github.com/irfansharif/or-tools v0.0.0-20210806150710-7bf371607f5d h1:m/iQkO+XU8XYoozqrHTdDufMkCzRJzuQWZIt0QVZWAM=
+github.com/irfansharif/or-tools v0.0.0-20210806150710-7bf371607f5d/go.mod h1:R/dumbSyTGDtltABqk8bHM3YHisdUCW46mEc1eSqCkY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -19,6 +19,7 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## Context
Aligned with @musanimu today on how we want to do this, the first option being treating replicas as separate ranges, allocating a separate row inside the assignment matrix, and keeping track of which indices inside said matrix represent replicas belonging to the same range. Brushed this off due to memory expense and book-keeping replica-range relationships. Instead we agreed on extending the current implementation to track `replica-node` assignments versus `range-node` assignments. Id est, `[i][j] == 1` informs replica `i` allocated to node `j`. Meaning, for a typical assignment, a single row `i` would contain all the information inside it's entries as to how `r` replicas were allocated. 
Example : 
`assignmentMatrix := [[0,1,0,1], [1,1,0,0], [1,0,1,0]]` reads as : my first range's replicas are allocated to nodes `1, 3`, my second range's replicas are allocated to nodes `0, 1`, and my final range replica's are allocated to nodes `1, 2`.

## Testing
Tests to be added by @musanimu.

## Comments
I cleaned up a-lot of the `go` logic as part of this PR, feedback appreciated. 