### PR TITLE
[OPTs] Make timeout configurable and improve naming.

### DIFF
--- a/allocator.go
+++ b/allocator.go
@@ -341,7 +341,7 @@ func (a *Allocator) Allocate() (ok bool, allocation Allocation) {
 
 	// set a hard time limit of 10s on our solver.
 	result := a.model.Solve(solver.WithTimeout(a.opts.searchTimeout))
-	if result.Infeasible() || result.Invalid() {
+	if !(result.Feasible() || result.Optimal()) {
 		return false, nil
 	}
 

--- a/allocator.go
+++ b/allocator.go
@@ -20,8 +20,9 @@ type Resource int
 type Allocation map[RangeID][]NodeID
 
 const (
-	noMaxChurn            = -1
-	DiskResource Resource = iota
+	noMaxChurn              = -1
+	defaultTimeout          = time.Second * 10
+	DiskResource   Resource = iota
 	Qps
 )
 
@@ -59,6 +60,8 @@ type options struct {
 	maxChurn int64
 	// prevAssignment holds some prior allocation.
 	prevAssignment map[RangeID][]NodeID
+	// searchTimeout forces the solver to return within the specified duration.
+	searchTimeout time.Duration
 }
 
 // Option manifests a closure that mutates allocation configurations in accordance with caller preferences.
@@ -115,6 +118,7 @@ func New(ranges []Range, nodes []Node, opts ...Option) *Allocator {
 	defaultOptions := options{}
 	// assume no maxChurn initially, let the options slice override if needed.
 	defaultOptions.maxChurn = noMaxChurn
+	defaultOptions.searchTimeout = defaultTimeout
 	for _, opt := range opts {
 		opt(&defaultOptions)
 	}
@@ -147,9 +151,9 @@ func (a Allocation) Print() {
 	}
 }
 
-// WithNodeCapacity is a closure that configures the allocator to adhere to capacity constraints and load-balance across
+// WithResources is a closure that configures the allocator to adhere to capacity constraints and load-balance across
 // resources.
-func WithNodeCapacity() Option {
+func WithResources() Option {
 	return func(opt *options) {
 		opt.withResources = true
 	}
@@ -187,7 +191,14 @@ func WithChurnMinimized() Option {
 	}
 }
 
-func (a *Allocator) adhereToNodeResources() {
+// WithTimeout is a closure that configures the allocator to conclude its search within the duration provided.
+func WithTimeout(searchTimeout time.Duration) Option {
+	return func(opt *options) {
+		opt.searchTimeout = searchTimeout
+	}
+}
+
+func (a *Allocator) adhereToResourcesAndBalance() {
 	// build a fixed offset of size one initially to avoid polluting the constant set with unnecessary variables.
 	// we can use this across loop iterations, since this is used only to indicate the distance between intervals starts + ends.
 	fixedSizedOneOffset := a.model.NewConstant(1, fmt.Sprintf("Fixed offset of size 1."))
@@ -308,7 +319,7 @@ func (a *Allocator) adhereToChurnConstraint() {
 func (a *Allocator) Allocate() (ok bool, allocation Allocation) {
 	// add constraints given opts/configurations.
 	if a.opts.withResources {
-		a.adhereToNodeResources()
+		a.adhereToResourcesAndBalance()
 	}
 
 	if a.opts.withTagAffinity {
@@ -329,7 +340,7 @@ func (a *Allocator) Allocate() (ok bool, allocation Allocation) {
 	}
 
 	// set a hard time limit of 10s on our solver.
-	result := a.model.Solve(solver.WithTimeout(time.Second * 10))
+	result := a.model.Solve(solver.WithTimeout(a.opts.searchTimeout))
 	if result.Infeasible() || result.Invalid() {
 		return false, nil
 	}

--- a/allocator_test.go
+++ b/allocator_test.go
@@ -58,7 +58,7 @@ func TestCapacity(t *testing.T) {
 		rangeDemands[i] = map[allocator.Resource]int64{allocator.DiskResource: int64(i)}
 	}
 	ranges := buildRanges(numRanges, rf, rangeDemands, buildEmptyTags(numRanges))
-	status, allocation := allocator.New(ranges, nodes, allocator.WithNodeCapacity()).Allocate()
+	status, allocation := allocator.New(ranges, nodes, allocator.WithResources()).Allocate()
 	require.True(t, status)
 	for _, nodeAssignments := range allocation {
 		require.Equal(t, len(nodeAssignments), rf)
@@ -79,7 +79,7 @@ func TestCapacityTogetherWithReplication(t *testing.T) {
 	}
 	nodes := buildNodes(numNodes, clusterCapacities, buildEmptyTags(numNodes))
 	ranges := buildRanges(numRanges, rf, rangeDemands, buildEmptyTags(numRanges))
-	status, allocation := allocator.New(ranges, nodes, allocator.WithNodeCapacity()).Allocate()
+	status, allocation := allocator.New(ranges, nodes, allocator.WithResources()).Allocate()
 	require.True(t, status)
 	for _, nodeAssignments := range allocation {
 		require.Equal(t, len(nodeAssignments), rf)
@@ -102,7 +102,7 @@ func TestCapacityWithInfeasibleRF(t *testing.T) {
 	}
 	nodes := buildNodes(numNodes, clusterCapacities, buildEmptyTags(numNodes))
 	ranges := buildRanges(numRanges, rf, rangeDemands, buildEmptyTags(numRanges))
-	status, allocation := allocator.New(ranges, nodes, allocator.WithNodeCapacity()).Allocate()
+	status, allocation := allocator.New(ranges, nodes, allocator.WithResources()).Allocate()
 	require.False(t, status)
 	require.Nil(t, allocation)
 }
@@ -119,7 +119,7 @@ func TestCapacityWithInsufficientNodes(t *testing.T) {
 		rangeDemands[i] = map[allocator.Resource]int64{allocator.DiskResource: rangeSizeDemands[i]}
 	}
 	ranges := buildRanges(numRanges, rf, rangeDemands, buildEmptyTags(numRanges))
-	status, allocation := allocator.New(ranges, nodes, allocator.WithNodeCapacity()).Allocate()
+	status, allocation := allocator.New(ranges, nodes, allocator.WithResources()).Allocate()
 	require.False(t, status)
 	require.Nil(t, allocation)
 }
@@ -212,7 +212,7 @@ func TestQPSandDiskBalancing(t *testing.T) {
 		qpsDemands += i
 	}
 	ranges := buildRanges(numRanges, rf, rangeDemands, buildEmptyTags(numRanges))
-	status, allocation := allocator.New(ranges, nodes, allocator.WithNodeCapacity()).Allocate()
+	status, allocation := allocator.New(ranges, nodes, allocator.WithResources()).Allocate()
 	require.True(t, status)
 	reasonableVariance := 0.2
 	idealSizeAllocation := float64(sizeDemands+qpsDemands) / float64(numNodes)


### PR DESCRIPTION
Makes the search timeout configurable by caller (we'll need this for benchmarking) and also improves some of the legacy naming that is now obsolete.