### PR TITLE
Interface-work

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -9,7 +9,7 @@ gazelle(
 
 go_library(
     name = "allocator",
-    srcs = ["allocator.go"],
+    srcs = ["allocator.go", "cluster.go", "node.go", "replica.go"],
     importpath = "github.com/smcheema/allocator",
     visibility = ["//visibility:public"],
     deps = ["@com_github_irfansharif_solver//:solver"],

--- a/allocator.go
+++ b/allocator.go
@@ -78,83 +78,71 @@ type Allocator struct {
 	opts options
 }
 
-type NodeInterface struct{
-	n Node
-	NodeMap map[NodeID]Node
-}
+type NodeMap map[NodeID]Node
+type RangeMap map[RangeID]Range
 
-type RangeInterface struct {
-	r        Range
-	RangeMap map[RangeID]Range
-}
-
-type Cluster interface {
-	ClusterWriter
-}
-
-type ClusterWriter interface{
+type Cluster interface{
 	AddNode()
+	UpdateNodeTags () bool
+	UpdateNodeResources() bool
 	RemoveNode () bool
 	AddRange ()
 	RemoveRange () bool
 }
 
-// AddNode Update or Add a new Node
-func(ni NodeInterface) AddNode() {
-	ni.NodeMap[ni.n.id] = ni.n
+// AddNode Add a new Node
+func (nmap NodeMap) AddNode(id NodeID, tags []string, resources map[Resource]int64) {
+	nmap[id] = Node {
+		id:        id,
+		tags:      tags,
+		resources: resources,
+	}
 }
 
-//Remove the node if its in the map
-func(ni NodeInterface) RemoveNode() bool{
-
-	if _, found := ni.NodeMap[ni.n.id]; found {
-		fmt.Println("Removing Node ", ni.n.id)
-		delete(ni.NodeMap,ni.n.id)
+// UpdateNodeTags Update tags of a Node
+func (nmap NodeMap) UpdateNodeTags(id NodeID, tags []string) bool {
+	if _, found := nmap[id]; found {
+		fmt.Println("Updating Node Tag ", id)
+		nmap[id]= Node {
+			id:        id,
+			tags:      tags,
+			resources: nmap[id].resources,
+		}
 		return true
 	}
-	fmt.Println("Node not found ", ni.n.id)
+	fmt.Println("Node not found ", id)
+	return false
+}
+
+// UpdateNodeResources Update Resources of a Node
+func (nmap NodeMap) UpdateNodeResources(id NodeID, resources map[Resource]int64) bool {
+	if _, found := nmap[id]; found {
+		fmt.Println("Updating Node Resources ", id)
+		nmap[id]= Node {
+			id:        id,
+			tags:      nmap[id].tags,
+			resources: resources,
+		}
+		return true
+	}
+	fmt.Println("Node not found ", id)
+	return false
+}
+
+// RemoveNode Remove the node if its in the map
+func(nmap NodeMap) RemoveNode(n Node) bool{
+
+	if _, found := nmap[n.id]; found {
+		fmt.Println("Removing Node ", n.id)
+		delete(nmap,n.id)
+		return true
+	}
+	fmt.Println("Node not found ", n.id)
 	return true
 }
 
-func(ri RangeInterface) AddRange() {
-	ri.RangeMap[ri.r.id] = ri.r
-}
-
-//Remove the range if its in the map
-func(ri RangeInterface) RemoveRange() bool{
-
-	if _, found := ri.RangeMap[ri.r.id]; found {
-		fmt.Println("Removing Range ", ri.r.id)
-		delete(ri.RangeMap,ri.r.id)
-		return true
-	}
-	fmt.Println("Range not found ", ri.r.id)
-	return true
-}
-
-func createRangeMap(ranges []Range) map[RangeID]Range{
-
-	idToRangeMap := make(map[RangeID]Range)
-	for _, r := range ranges {
-		idToRangeMap[r.id] = r
-	}
-
-	return idToRangeMap
-}
-
-func createNodeMap(nodes []Node) map[NodeID]Node{
-
-	idToNodeMap := make(map[NodeID]Node)
-	for _, n := range nodes {
-		idToNodeMap[n.id] = n
-	}
-
-	return idToNodeMap
-}
-
-// NewRange builds and returns ranges from the necessary parameters.
-func NewRange(id RangeID, rf int, tags []string, demands map[Resource]int64) Range {
-	return Range{
+func(rmap RangeMap) AddRange(id RangeID, rf int, tags []string, demands map[Resource]int64) {
+	rmap[id]= Range{
 		id:      id,
 		rf:      rf,
 		tags:    tags,
@@ -162,27 +150,30 @@ func NewRange(id RangeID, rf int, tags []string, demands map[Resource]int64) Ran
 	}
 }
 
-// NewNode builds and returns nodes from the necessary parameters.
-func NewNode(id NodeID, tags []string, resources map[Resource]int64) Node {
-	return Node{
-		id:        id,
-		tags:      tags,
-		resources: resources,
+// RemoveRange Remove the range if its in the map
+func(rmap RangeMap) RemoveRange(r Range) bool{
+
+	if _, found := rmap[r.id]; found {
+		fmt.Println("Removing Range ", r.id)
+		delete(rmap,r.id)
+		return true
 	}
+	fmt.Println("Range not found ", r.id)
+	return true
 }
 
 // New builds, configures, and returns an allocator from the necessary parameters.
-func New(ranges []Range, nodes []Node, opts ...Option) *Allocator {
+func New(idRangeMap RangeMap, idNodeMap NodeMap, opts ...Option) *Allocator {
 	model := solver.NewModel("Lé-Allocator")
 	assignment := make(map[RangeID][]solver.IntVar)
 	// iterate over ranges, assign each rangeID a list of IV's sized r.rf.
 	// These will ultimately then read as: rangeID's replicas assigned to nodes [N.1, N.2,...N.RF]
-	for _, r := range ranges {
+	for _, r := range idRangeMap {
 		assignment[r.id] = make([]solver.IntVar, r.rf)
 		for j := range assignment[r.id] {
 			// constrain our IV's to live between [0, len(nodes) - 1].
 			assignment[r.id][j] = model.NewIntVarFromDomain(
-				solver.NewDomain(int64(nodes[0].id), int64(nodes[len(nodes)-1].id)),
+				solver.NewDomain(int64(idNodeMap[0].id), int64(idNodeMap[NodeID(len(idNodeMap)-1)].id)),
 				fmt.Sprintf("Allocation var for r.id:%d.", r.id))
 		}
 	}
@@ -193,15 +184,9 @@ func New(ranges []Range, nodes []Node, opts ...Option) *Allocator {
 		opt(&defaultOptions)
 	}
 
-	// build a convenience id-to-struct mapping for ranges.
-	idToRangeMap := createRangeMap(ranges)
-
-	// build a convenience id-to-struct mapping for nodes.
-	idToNodeMap := createNodeMap(nodes)
-
 	return &Allocator{
-		ranges:     idToRangeMap,
-		nodes:      idToNodeMap,
+		ranges:     idRangeMap,
+		nodes:      idNodeMap,
 		model:      model,
 		assignment: assignment,
 		opts:       defaultOptions,

--- a/allocator.go
+++ b/allocator.go
@@ -83,8 +83,8 @@ type ClusterRMap map[RangeID]*Range
 
 
 // AddNode Add a new Node
-func (nmap ClusterNMap) AddNode(id NodeID, tags []string, nodeCapacity int64) {
-	nmap[id] = &Node {
+func (nmap *ClusterNMap) AddNode(id NodeID, tags []string, nodeCapacity int64) {
+	(*nmap)[id] = &Node {
 		id:        id,
 		tags:      tags,
 		resources: map[Resource]*int64 {DiskResource: &nodeCapacity},
@@ -92,10 +92,10 @@ func (nmap ClusterNMap) AddNode(id NodeID, tags []string, nodeCapacity int64) {
 }
 
 // UpdateNodeTags Update tags of a Node
-func (nmap ClusterNMap) UpdateNodeTags(id NodeID, tags []string) bool {
-	if _, found := nmap[id]; found {
+func (nmap *ClusterNMap) UpdateNodeTags(id NodeID, tags []string) bool {
+	if _, found := (*nmap)[id]; found {
 		fmt.Println("Updating Node Tag ", id)
-		nmap[id].tags=tags
+		(*nmap)[id].tags=tags
 		return true
 	}
 	fmt.Println("Node not found ", id)
@@ -103,10 +103,10 @@ func (nmap ClusterNMap) UpdateNodeTags(id NodeID, tags []string) bool {
 }
 
 // UpdateNodeResources Update Resources of a Node
-func (nmap ClusterNMap) UpdateNodeCapacity(id NodeID, nodeCapacity int64) bool {
-	if _, found := nmap[id]; found {
+func (nmap *ClusterNMap) UpdateNodeCapacity(id NodeID, nodeCapacity int64) bool {
+	if _, found := (*nmap)[id]; found {
 		fmt.Println("Updating Node Resources ", id)
-		nmap[id].resources[DiskResource]=&nodeCapacity
+		(*nmap)[id].resources[DiskResource]=&nodeCapacity
 		return true
 	}
 	fmt.Println("Node not found ", id)
@@ -114,19 +114,19 @@ func (nmap ClusterNMap) UpdateNodeCapacity(id NodeID, nodeCapacity int64) bool {
 }
 
 // RemoveNode Remove the node if its in the map
-func(nmap ClusterNMap) RemoveNode(n Node) bool{
+func(nmap *ClusterNMap) RemoveNode(n Node) bool{
 
-	if _, found := nmap[n.id]; found {
+	if _, found := (*nmap)[n.id]; found {
 		fmt.Println("Removing Node ", n.id)
-		delete(nmap,n.id)
+		delete((*nmap),n.id)
 		return true
 	}
 	fmt.Println("Node not found ", n.id)
 	return true
 }
 
-func(rmap ClusterRMap) AddRange(id RangeID, rf int, tags []string, demands map[Resource]int64) {
-	rmap[id]= &Range{
+func(rmap *ClusterRMap) AddRange(id RangeID, rf int, tags []string, demands map[Resource]int64) {
+	(*rmap)[id]= &Range{
 		id:      id,
 		rf:      rf,
 		tags:    tags,
@@ -135,11 +135,11 @@ func(rmap ClusterRMap) AddRange(id RangeID, rf int, tags []string, demands map[R
 }
 
 // RemoveRange Remove the range if its in the map
-func(rmap ClusterRMap) RemoveRange(r Range) bool{
+func(rmap *ClusterRMap) RemoveRange(r Range) bool{
 
-	if _, found := rmap[r.id]; found {
+	if _, found := (*rmap)[r.id]; found {
 		fmt.Println("Removing Range ", r.id)
-		delete(rmap,r.id)
+		delete((*rmap),r.id)
 		return true
 	}
 	fmt.Println("Range not found ", r.id)
@@ -147,10 +147,10 @@ func(rmap ClusterRMap) RemoveRange(r Range) bool{
 }
 
 // UpdateRangeTags Update tags of Range
-func (rmap ClusterRMap) UpdateRangeTags(id RangeID, tags []string) bool {
-	if _, found := rmap[id]; found {
+func (rmap *ClusterRMap) UpdateRangeTags(id RangeID, tags []string) bool {
+	if _, found := (*rmap)[id]; found {
 		fmt.Println("Updating Range Tag ", id)
-		rmap[id].tags=tags
+		(*rmap)[id].tags=tags
 		return true
 	}
 	fmt.Println("Range not found ", id)
@@ -158,10 +158,10 @@ func (rmap ClusterRMap) UpdateRangeTags(id RangeID, tags []string) bool {
 }
 
 // UpdateRangeTags Update Demands of Range
-func (rmap ClusterRMap) UpdateRangeDemands(id RangeID, demands map[Resource]int64) bool {
-	if _, found := rmap[id]; found {
+func (rmap *ClusterRMap) UpdateRangeDemands(id RangeID, demands map[Resource]int64) bool {
+	if _, found := (*rmap)[id]; found {
 		fmt.Println("Updating Range Demands ", id)
-		rmap[id].demands=demands
+		(*rmap)[id].demands=demands
 		return true
 	}
 	fmt.Println("Range not found ", id)

--- a/allocator.go
+++ b/allocator.go
@@ -44,7 +44,7 @@ type Node struct {
 	// tags are strings that showcase affinity for ranges.
 	tags []string
 	// resources model the resource profile of said node.
-	resources map[Resource]int64
+	resources map[Resource]*int64
 }
 
 // options hold runtime allocation configurations.
@@ -67,9 +67,9 @@ type Option func(*options)
 // Allocator holds the ranges, nodes, underlying CP-SAT solver, assigment variables, and configuration needed.
 type Allocator struct {
 	// ranges are a mapping of RangeID onto the Range struct.
-	ranges map[RangeID]Range
+	ranges map[RangeID]*Range
 	// nodes are a mapping of NodeID onto the Node struct.
-	nodes map[NodeID]Node
+	nodes map[NodeID]*Node
 	// model is the underlying CP-SAT solver and the engine of this package.
 	model *solver.Model
 	// assignment represents variables that we constrain and impose on to satisfy allocation requirements.
@@ -78,36 +78,24 @@ type Allocator struct {
 	opts options
 }
 
-type NodeMap map[NodeID]Node
-type RangeMap map[RangeID]Range
+type ClusterNMap map[NodeID]*Node
+type ClusterRMap map[RangeID]*Range
 
-type Cluster interface{
-	AddNode()
-	UpdateNodeTags () bool
-	UpdateNodeResources() bool
-	RemoveNode () bool
-	AddRange ()
-	RemoveRange () bool
-}
 
 // AddNode Add a new Node
-func (nmap NodeMap) AddNode(id NodeID, tags []string, resources map[Resource]int64) {
-	nmap[id] = Node {
+func (nmap ClusterNMap) AddNode(id NodeID, tags []string, nodeCapacity int64) {
+	nmap[id] = &Node {
 		id:        id,
 		tags:      tags,
-		resources: resources,
+		resources: map[Resource]*int64 {DiskResource: &nodeCapacity},
 	}
 }
 
 // UpdateNodeTags Update tags of a Node
-func (nmap NodeMap) UpdateNodeTags(id NodeID, tags []string) bool {
+func (nmap ClusterNMap) UpdateNodeTags(id NodeID, tags []string) bool {
 	if _, found := nmap[id]; found {
 		fmt.Println("Updating Node Tag ", id)
-		nmap[id]= Node {
-			id:        id,
-			tags:      tags,
-			resources: nmap[id].resources,
-		}
+		nmap[id].tags=tags
 		return true
 	}
 	fmt.Println("Node not found ", id)
@@ -115,14 +103,10 @@ func (nmap NodeMap) UpdateNodeTags(id NodeID, tags []string) bool {
 }
 
 // UpdateNodeResources Update Resources of a Node
-func (nmap NodeMap) UpdateNodeResources(id NodeID, resources map[Resource]int64) bool {
+func (nmap ClusterNMap) UpdateNodeCapacity(id NodeID, nodeCapacity int64) bool {
 	if _, found := nmap[id]; found {
 		fmt.Println("Updating Node Resources ", id)
-		nmap[id]= Node {
-			id:        id,
-			tags:      nmap[id].tags,
-			resources: resources,
-		}
+		nmap[id].resources[DiskResource]=&nodeCapacity
 		return true
 	}
 	fmt.Println("Node not found ", id)
@@ -130,7 +114,7 @@ func (nmap NodeMap) UpdateNodeResources(id NodeID, resources map[Resource]int64)
 }
 
 // RemoveNode Remove the node if its in the map
-func(nmap NodeMap) RemoveNode(n Node) bool{
+func(nmap ClusterNMap) RemoveNode(n Node) bool{
 
 	if _, found := nmap[n.id]; found {
 		fmt.Println("Removing Node ", n.id)
@@ -141,8 +125,8 @@ func(nmap NodeMap) RemoveNode(n Node) bool{
 	return true
 }
 
-func(rmap RangeMap) AddRange(id RangeID, rf int, tags []string, demands map[Resource]int64) {
-	rmap[id]= Range{
+func(rmap ClusterRMap) AddRange(id RangeID, rf int, tags []string, demands map[Resource]int64) {
+	rmap[id]= &Range{
 		id:      id,
 		rf:      rf,
 		tags:    tags,
@@ -151,7 +135,7 @@ func(rmap RangeMap) AddRange(id RangeID, rf int, tags []string, demands map[Reso
 }
 
 // RemoveRange Remove the range if its in the map
-func(rmap RangeMap) RemoveRange(r Range) bool{
+func(rmap ClusterRMap) RemoveRange(r Range) bool{
 
 	if _, found := rmap[r.id]; found {
 		fmt.Println("Removing Range ", r.id)
@@ -162,8 +146,30 @@ func(rmap RangeMap) RemoveRange(r Range) bool{
 	return true
 }
 
+// UpdateRangeTags Update tags of Range
+func (rmap ClusterRMap) UpdateRangeTags(id RangeID, tags []string) bool {
+	if _, found := rmap[id]; found {
+		fmt.Println("Updating Range Tag ", id)
+		rmap[id].tags=tags
+		return true
+	}
+	fmt.Println("Range not found ", id)
+	return false
+}
+
+// UpdateRangeTags Update Demands of Range
+func (rmap ClusterRMap) UpdateRangeDemands(id RangeID, demands map[Resource]int64) bool {
+	if _, found := rmap[id]; found {
+		fmt.Println("Updating Range Demands ", id)
+		rmap[id].demands=demands
+		return true
+	}
+	fmt.Println("Range not found ", id)
+	return false
+}
+
 // New builds, configures, and returns an allocator from the necessary parameters.
-func New(idRangeMap RangeMap, idNodeMap NodeMap, opts ...Option) *Allocator {
+func New(idRangeMap ClusterRMap, idClusterNMap ClusterNMap, opts ...Option) *Allocator {
 	model := solver.NewModel("Lé-Allocator")
 	assignment := make(map[RangeID][]solver.IntVar)
 	// iterate over ranges, assign each rangeID a list of IV's sized r.rf.
@@ -173,7 +179,7 @@ func New(idRangeMap RangeMap, idNodeMap NodeMap, opts ...Option) *Allocator {
 		for j := range assignment[r.id] {
 			// constrain our IV's to live between [0, len(nodes) - 1].
 			assignment[r.id][j] = model.NewIntVarFromDomain(
-				solver.NewDomain(int64(idNodeMap[0].id), int64(idNodeMap[NodeID(len(idNodeMap)-1)].id)),
+				solver.NewDomain(int64(idClusterNMap[0].id), int64(idClusterNMap[NodeID(len(idClusterNMap)-1)].id)),
 				fmt.Sprintf("Allocation var for r.id:%d.", r.id))
 		}
 	}
@@ -186,7 +192,7 @@ func New(idRangeMap RangeMap, idNodeMap NodeMap, opts ...Option) *Allocator {
 
 	return &Allocator{
 		ranges:     idRangeMap,
-		nodes:      idNodeMap,
+		nodes:      idClusterNMap,
 		model:      model,
 		assignment: assignment,
 		opts:       defaultOptions,
@@ -249,7 +255,7 @@ func (a *Allocator) adhereToNodeResources() {
 		// compute availability of node capacity. If not defined, assume we have just enough to
 		// allocate the entire load on EACH node. This helps keep our bounds tight, as opposed to an arbitrary number.
 		if c, ok := a.nodes[0].resources[re]; ok {
-			rawCapacity = c
+			rawCapacity = *c
 		} else {
 			for _, r := range a.ranges {
 				rawCapacity += r.demands[re]

--- a/allocator.go
+++ b/allocator.go
@@ -67,9 +67,9 @@ type Option func(*options)
 // Allocator holds the ranges, nodes, underlying CP-SAT solver, assigment variables, and configuration needed.
 type Allocator struct {
 	// ranges are a mapping of rangeId onto the ckRange struct.
-	ranges map[rangeId]*ckRange
+	ranges map[rangeId]ckRange
 	// nodes are a mapping of nodeId onto the node struct.
-	nodes map[nodeId]*node
+	nodes map[nodeId]node
 	// model is the underlying CP-SAT solver and the engine of this package.
 	model *solver.Model
 	// assignment represents variables that we constrain and impose on to satisfy allocation requirements.
@@ -79,27 +79,27 @@ type Allocator struct {
 }
 
 type Cluster struct {
-	nodes map[nodeId]*node
+	nodes map[nodeId]node
 }
 type Items struct {
-	ranges map[rangeId]*ckRange
+	ranges map[rangeId]ckRange
 }
 
 func NewCluster() Cluster {
 	return Cluster{
-		nodes: make(map[nodeId]*node),
+		nodes: make(map[nodeId]node),
 	}
 }
 
 func NewItems() Items {
 	return Items{
-		ranges: make(map[rangeId]*ckRange),
+		ranges: make(map[rangeId]ckRange),
 	}
 }
 
 // AddNode adds a node into the cluster collection.
 func (c Cluster) AddNode(id int64, nodeCapacity int64, tags ...string) {
-	c.nodes[nodeId(id)] = &node{
+	c.nodes[nodeId(id)] = node{
 		id:        nodeId(id),
 		tags:      tags,
 		resources: map[resource]int64{diskResource: nodeCapacity},
@@ -138,7 +138,7 @@ func (c Cluster) RemoveNode(id int64) bool {
 
 // AddRange adds a range into the items' collection.
 func (i Items) AddRange(id int64, rf int, diskDemand int64, q int64, tags ...string) {
-	i.ranges[rangeId(id)] = &ckRange{
+	i.ranges[rangeId(id)] = ckRange{
 		id:      rangeId(id),
 		rf:      rf,
 		tags:    tags,

--- a/allocator.go
+++ b/allocator.go
@@ -13,9 +13,9 @@ import (
 type Allocation map[int64][]int64
 
 const (
-	noMaxChurn              = -1
-	defaultTimeout          = time.Second * 10
-	loggingPrefix           = ""
+	noMaxChurn     = -1
+	defaultTimeout = time.Second * 10
+	loggingPrefix  = ""
 )
 
 // allocOptions hold runtime allocation configurations.
@@ -55,7 +55,7 @@ func newAllocator(cs *ClusterState, opts ...AllocOption) *allocator {
 	assignment := make(map[replicaId][]solver.IntVar)
 	defaultOptions := allocOptions{
 		// assume no maxChurn initially, let the allocOptions slice override if needed.
-		maxChurn: noMaxChurn,
+		maxChurn:      noMaxChurn,
 		searchTimeout: defaultTimeout,
 	}
 

--- a/allocator.go
+++ b/allocator.go
@@ -49,7 +49,7 @@ type allocator struct {
 }
 
 // newAllocator builds, configures, and returns an allocator from the necessary parameters.
-// Note this allocator should not be reused carefully after solving a problem
+// Note this allocator should not be reused after solving a problem because the underlying solver is stateful
 func newAllocator(cs *ClusterState, opts ...AllocOption) *allocator {
 	model := solver.NewModel("Lé-allocator")
 	assignment := make(map[replicaId][]solver.IntVar)
@@ -72,8 +72,7 @@ func newAllocator(cs *ClusterState, opts ...AllocOption) *allocator {
 }
 
 func Solve(cs *ClusterState, opts ...AllocOption) (ok bool, allocation Allocation) {
-	allocator := newAllocator(cs, opts...)
-	return allocator.allocate()
+	return newAllocator(cs, opts...).allocate()
 }
 
 // Print is a utility method that pretty-prints allocation information.

--- a/allocator.go
+++ b/allocator.go
@@ -78,6 +78,80 @@ type Allocator struct {
 	opts options
 }
 
+type NodeInterface struct{
+	n Node
+	NodeMap map[NodeID]Node
+}
+
+type RangeInterface struct {
+	r        Range
+	RangeMap map[RangeID]Range
+}
+
+type Cluster interface {
+	ClusterWriter
+}
+
+type ClusterWriter interface{
+	AddNode()
+	RemoveNode () bool
+	AddRange ()
+	RemoveRange () bool
+}
+
+// AddNode Update or Add a new Node
+func(ni NodeInterface) AddNode() {
+	ni.NodeMap[ni.n.id] = ni.n
+}
+
+//Remove the node if its in the map
+func(ni NodeInterface) RemoveNode() bool{
+
+	if _, found := ni.NodeMap[ni.n.id]; found {
+		fmt.Println("Removing Node ", ni.n.id)
+		delete(ni.NodeMap,ni.n.id)
+		return true
+	}
+	fmt.Println("Node not found ", ni.n.id)
+	return true
+}
+
+func(ri RangeInterface) AddRange() {
+	ri.RangeMap[ri.r.id] = ri.r
+}
+
+//Remove the range if its in the map
+func(ri RangeInterface) RemoveRange() bool{
+
+	if _, found := ri.RangeMap[ri.r.id]; found {
+		fmt.Println("Removing Range ", ri.r.id)
+		delete(ri.RangeMap,ri.r.id)
+		return true
+	}
+	fmt.Println("Range not found ", ri.r.id)
+	return true
+}
+
+func createRangeMap(ranges []Range) map[RangeID]Range{
+
+	idToRangeMap := make(map[RangeID]Range)
+	for _, r := range ranges {
+		idToRangeMap[r.id] = r
+	}
+
+	return idToRangeMap
+}
+
+func createNodeMap(nodes []Node) map[NodeID]Node{
+
+	idToNodeMap := make(map[NodeID]Node)
+	for _, n := range nodes {
+		idToNodeMap[n.id] = n
+	}
+
+	return idToNodeMap
+}
+
 // NewRange builds and returns ranges from the necessary parameters.
 func NewRange(id RangeID, rf int, tags []string, demands map[Resource]int64) Range {
 	return Range{
@@ -120,16 +194,10 @@ func New(ranges []Range, nodes []Node, opts ...Option) *Allocator {
 	}
 
 	// build a convenience id-to-struct mapping for ranges.
-	idToRangeMap := make(map[RangeID]Range)
-	for _, r := range ranges {
-		idToRangeMap[r.id] = r
-	}
+	idToRangeMap := createRangeMap(ranges)
 
 	// build a convenience id-to-struct mapping for nodes.
-	idToNodeMap := make(map[NodeID]Node)
-	for _, n := range nodes {
-		idToNodeMap[n.id] = n
-	}
+	idToNodeMap := createNodeMap(nodes)
 
 	return &Allocator{
 		ranges:     idToRangeMap,

--- a/allocator.go
+++ b/allocator.go
@@ -6,49 +6,16 @@ import (
 	"time"
 )
 
-// nodeId is a 64-bit identifier for nodes.
-type nodeId int64
-
-// rangeId is a 64-bit identifier for ranges.
-type rangeId int64
-
-// resource is 32-bit identifier for resources -> {disk, qps}
-type resource int
-
 // Allocation is the return type of our allocator.
-// It models mappings of RangeIDs to a list of NodeIDs.
+// It models mappings of ReplicaIDs to a list of NodeIDs.
 type Allocation map[int64][]int64
 
 const (
-	noMaxChurn            = -1
-	diskResource resource = iota
-	qps
+	noMaxChurn = -1
 )
 
-// ckRange encapsulates pertaining metadata for cockroachDB ranges.
-type ckRange struct {
-	// id represents a unique identifier.
-	id rangeId
-	// rf equals the replication factor of said range.
-	rf int
-	// tags are strings that showcase affinity for nodes.
-	tags []string
-	// demands model the resource requirements of said range.
-	demands map[resource]int64
-}
-
-// node encapsulates pertaining metadata for cockroachDB nodes.
-type node struct {
-	// id represents a unique identifier.
-	id nodeId
-	// tags are strings that showcase affinity for ranges.
-	tags []string
-	// resources model the resource profile of said node.
-	resources map[resource]int64
-}
-
-// options hold runtime allocation configurations.
-type options struct {
+// allocOptions hold runtime allocation configurations.
+type allocOptions struct {
 	// withResources signals the allocator to perform balancing and capacity checking.
 	withResources bool
 	// withTagAffinity forces the allocator to perform affine allocations only.
@@ -57,193 +24,75 @@ type options struct {
 	withMinimalChurn bool
 	// maxChurn limits the number of moves needed to fulfill an allocation request with respect to a prior allocation.
 	maxChurn int64
-	// prevAssignment holds some prior allocation.
-	prevAssignment map[rangeId][]nodeId
 }
 
-// Option manifests a closure that mutates allocation configurations in accordance with caller preferences.
-type Option func(*options)
+// AllocOption manifests a closure that mutates allocation configurations in accordance with caller preferences.
+type AllocOption func(*allocOptions)
 
-// Allocator holds the ranges, nodes, underlying CP-SAT solver, assigment variables, and configuration needed.
-type Allocator struct {
-	// ranges are a mapping of rangeId onto the ckRange struct.
-	ranges map[rangeId]ckRange
-	// nodes are a mapping of nodeId onto the node struct.
-	nodes map[nodeId]node
+// allocator holds the replicas, nodes, underlying CP-SAT solver, assigment variables, and configuration needed.
+type allocator struct {
+	*ClusterState
 	// model is the underlying CP-SAT solver and the engine of this package.
 	model *solver.Model
 	// assignment represents variables that we constrain and impose on to satisfy allocation requirements.
-	assignment map[rangeId][]solver.IntVar
+	assignment map[replicaId][]solver.IntVar
 	// opts hold allocation configurations -> {withResources, withTagAffinity...}
-	opts options
+	opts allocOptions
 }
 
-type Cluster struct {
-	nodes map[nodeId]node
-}
-type Items struct {
-	ranges map[rangeId]ckRange
-}
-
-func NewCluster() Cluster {
-	return Cluster{
-		nodes: make(map[nodeId]node),
+// newAllocator builds, configures, and returns an allocator from the necessary parameters.
+// Note this allocator should not be reused carefully after solving a problem
+func newAllocator(cs *ClusterState, opts ...AllocOption) *allocator {
+	model := solver.NewModel("Lé-allocator")
+	assignment := make(map[replicaId][]solver.IntVar)
+	defaultOptions := allocOptions{
+		// assume no maxChurn initially, let the allocOptions slice override if needed.
+		maxChurn: noMaxChurn,
 	}
-}
 
-func NewItems() Items {
-	return Items{
-		ranges: make(map[rangeId]ckRange),
-	}
-}
-
-// AddNode adds a node into the cluster collection.
-func (c Cluster) AddNode(id int64, nodeCapacity int64, tags ...string) {
-	c.nodes[nodeId(id)] = node{
-		id:        nodeId(id),
-		tags:      tags,
-		resources: map[resource]int64{diskResource: nodeCapacity},
-	}
-}
-
-// UpdateNodeTags updates the tags for a node currently residing in the cluster collection,
-// returning true for a successful update, false if the nodeID does not map to any node.
-func (c Cluster) UpdateNodeTags(id int64, tags ...string) bool {
-	if n, found := c.nodes[nodeId(id)]; found {
-		n.tags = tags
-		return true
-	}
-	return false
-}
-
-// UpdateNodeCapacity updates the disk-capacity for a node currently residing in the cluster collection,
-// returning true for a successful update, false if the nodeID does not map to any node.
-func (c Cluster) UpdateNodeCapacity(id int64, nodeCapacity int64) bool {
-	if n, found := c.nodes[nodeId(id)]; found {
-		n.resources[diskResource] = nodeCapacity
-		return true
-	}
-	return false
-}
-
-// RemoveNode removes a given node from the cluster collection, returning true is the deletion is successful,
-// false if the nodeID does not map to any node.
-func (c Cluster) RemoveNode(id int64) bool {
-	if _, found := c.nodes[nodeId(id)]; found {
-		delete(c.nodes, nodeId(id))
-		return true
-	}
-	return false
-}
-
-// AddRange adds a range into the items' collection.
-func (i Items) AddRange(id int64, rf int, diskDemand int64, q int64, tags ...string) {
-	i.ranges[rangeId(id)] = ckRange{
-		id:      rangeId(id),
-		rf:      rf,
-		tags:    tags,
-		demands: map[resource]int64{diskResource: diskDemand, qps: q},
-	}
-}
-
-// RemoveRange removes a given range from the items' collection, returning true is the deletion is successful,
-// false if the rangeID does not map to any range.
-func (i Items) RemoveRange(id int64) bool {
-	if _, found := i.ranges[rangeId(id)]; found {
-		delete(i.ranges, rangeId(id))
-		return true
-	}
-	return false
-}
-
-// UpdateRangeTags updates the tags for a range currently residing in the items' collection,
-// returning true for a successful update, false if the rangeID does not map to any range.
-func (i Items) UpdateRangeTags(id int64, tags ...string) bool {
-	if r, found := i.ranges[rangeId(id)]; found {
-		r.tags = tags
-		return true
-	}
-	return false
-}
-
-// UpdateRangeDiskDemand updates the disk-demand for a range currently residing in the items' collection,
-// returning true for a successful update, false if the rangeID does not map to any range.
-func (i Items) UpdateRangeDiskDemand(id rangeId, diskDemand int64) bool {
-	if r, found := i.ranges[id]; found {
-		r.demands[diskResource] = diskDemand
-		return true
-	}
-	return false
-}
-
-// UpdateRangeQps updates the qps for a range currently residing in the items' collection,
-// returning true for a successful update, false if the rangeID does not map to any range.
-func (i Items) UpdateRangeQps(id int64, q int64) bool {
-	if r, found := i.ranges[rangeId(id)]; found {
-		r.demands[qps] = q
-		return true
-	}
-	return false
-}
-
-// New builds, configures, and returns an allocator from the necessary parameters.
-func New(opts ...Option) *Allocator {
-	model := solver.NewModel("Lé-Allocator")
-	assignment := make(map[rangeId][]solver.IntVar)
-	defaultOptions := options{}
-	// assume no maxChurn initially, let the options slice override if needed.
-	defaultOptions.maxChurn = noMaxChurn
 	for _, opt := range opts {
 		opt(&defaultOptions)
 	}
 
-	return &Allocator{
-		model:      model,
-		assignment: assignment,
-		opts:       defaultOptions,
+	return &allocator{
+		ClusterState: cs,
+		model:        model,
+		assignment:   assignment,
+		opts:         defaultOptions,
 	}
+}
+
+func Solve(cs *ClusterState, opts ...AllocOption) (ok bool, allocation Allocation) {
+	allocator := newAllocator(cs, opts...)
+	return allocator.allocate()
 }
 
 // Print is a utility method that pretty-prints allocation information.
 func (a Allocation) Print() {
-	for rangeID, nodeIDs := range a {
-		fmt.Println("ckRange with ID: ", rangeID, " on nodes: ", nodeIDs)
+	for replicaID, nodeIDs := range a {
+		fmt.Println("replica with ID: ", replicaID, " on nodes: ", nodeIDs)
 	}
 }
 
 // WithNodeCapacity is a closure that configures the allocator to adhere to capacity constraints and load-balance across
 // resources.
-func WithNodeCapacity() Option {
-	return func(opt *options) {
+func WithNodeCapacity() AllocOption {
+	return func(opt *allocOptions) {
 		opt.withResources = true
 	}
 }
 
 // WithTagMatching is a closure that configures the allocator to perform affine allocations only.
-func WithTagMatching() Option {
-	return func(opt *options) {
+func WithTagMatching() AllocOption {
+	return func(opt *allocOptions) {
 		opt.withTagAffinity = true
-	}
-}
-
-// WithPriorAssignment is a closure that ingests a prior allocation.
-func WithPriorAssignment(prevAssignment map[int64][]int64) Option {
-	temp := make(map[rangeId][]nodeId)
-	for r, n := range prevAssignment {
-		temp[rangeId(r)] = make([]nodeId, len(n))
-		for nid := range n {
-			temp[rangeId(r)] = append(temp[rangeId(r)], nodeId(nid))
-		}
-	}
-	return func(opt *options) {
-		opt.prevAssignment = temp
 	}
 }
 
 // WithMaxChurn is a closure that inspects and sets a hard limit on the maximum number of moves deviating
 // from some prior assignment.
-func WithMaxChurn(maxChurn int64) Option {
-	return func(opt *options) {
+func WithMaxChurn(maxChurn int64) AllocOption {
+	return func(opt *allocOptions) {
 		if maxChurn < 0 {
 			panic("max-churn must be greater than or equal to 0")
 		}
@@ -252,45 +101,45 @@ func WithMaxChurn(maxChurn int64) Option {
 }
 
 // WithChurnMinimized is a closure that configures the allocator to minimize variance from some prior allocation.
-func WithChurnMinimized() Option {
-	return func(opt *options) {
+func WithChurnMinimized() AllocOption {
+	return func(opt *allocOptions) {
 		opt.withMinimalChurn = true
 	}
 }
 
-func (a *Allocator) adhereToNodeResources() {
+func (a *allocator) adhereToNodeResources() {
 	// build a fixed offset of size one initially to avoid polluting the constant set with unnecessary variables.
 	// we can use this across loop iterations, since this is used only to indicate the distance between intervals starts + ends.
 	fixedSizedOneOffset := a.model.NewConstant(1, fmt.Sprintf("Fixed offset of size 1."))
-	for _, re := range []resource{diskResource, qps} {
+	for _, re := range []Resource{DiskResource, QPS} {
 		rawCapacity := int64(0)
 		// compute availability of node capacity. If not defined, assume we have just enough to
 		// allocate the entire load on EACH node. This helps keep our bounds tight, as opposed to an arbitrary number.
 		if c, ok := a.nodes[0].resources[re]; ok {
 			rawCapacity = c
 		} else {
-			for _, r := range a.ranges {
+			for _, r := range a.replicas {
 				rawCapacity += r.demands[re]
 			}
 		}
-		capacity := a.model.NewIntVar(0, rawCapacity, fmt.Sprintf("IV used to minimize variance and enforce capacity constraint for resource: %d", re))
+		capacity := a.model.NewIntVar(0, rawCapacity, fmt.Sprintf("IV used to minimize variance and enforce capacity constraint for Resource: %d", re))
 		tasks := make([]solver.Interval, 0)
-		// demands represent the resource requirements placed on each node by potential matches to a range.
+		// demands represent the resource requirements placed on each node by potential matches to a replica.
 		demands := make([]solver.IntVar, 0)
 		for rID, nIDs := range a.assignment {
 			for i, id := range nIDs {
-				// go over rangeIDs and their respective ivs.
-				// for that specific range, tell the allocator "regardless of where you place this replica, you will
+				// go over replicaIDs and their respective ivs.
+				// for that specific replica, tell the allocator "regardless of where you place this replica, you will
 				// pay a cost of r.resource[re]". What we're asking the allocator to do is then arrange the intervals
 				// in a fashion that does not violate our capacity requirements.
 				toAdd := a.model.NewInterval(
 					id,
 					a.model.NewIntVarFromDomain(solver.NewDomain(1, int64(len(a.nodes))), "Adjusted intervals for upper bounds."),
 					fixedSizedOneOffset,
-					fmt.Sprintf("Interval representing demands placed on node by range: %d, replica: %d", rID, i),
+					fmt.Sprintf("Interval representing demands placed on node by replica: %d, replica: %d", rID, i),
 				)
 				tasks = append(tasks, toAdd)
-				demands = append(demands, a.model.NewConstant(a.ranges[rID].demands[re], fmt.Sprintf("Demand for r.id:%d.", rID)))
+				demands = append(demands, a.model.NewConstant(a.replicas[rID].demands[re], fmt.Sprintf("Demand for r.id:%d.", rID)))
 			}
 		}
 		// set ceiling for interval interleaving.
@@ -303,12 +152,12 @@ func (a *Allocator) adhereToNodeResources() {
 	}
 }
 
-func (a *Allocator) adhereToNodeTags() {
-	for rID, r := range a.ranges {
+func (a *allocator) adhereToNodeTags() {
+	for rID, r := range a.replicas {
 		forbiddenAssignments := make([][]int64, 0)
-		// for each range-node pair, if incompatible, force the allocator to write-off said allocation.
+		// for each replica-node pair, if incompatible, force the allocator to write-off said allocation.
 		for nID, n := range a.nodes {
-			if !rangeTagsAreSubsetOfNodeTags(r.tags, n.tags) {
+			if !replicaTagsAreSubsetOfNodeTags(r.tags, n.tags) {
 				forbiddenAssignments = append(forbiddenAssignments, []int64{int64(nID)})
 			}
 		}
@@ -320,12 +169,12 @@ func (a *Allocator) adhereToNodeTags() {
 	}
 }
 
-// rangeTagsAreSubsetOfNodeTags returns true iff a range's tags are a subset of a node's tags
-func rangeTagsAreSubsetOfNodeTags(rangeTags []string, nodeTags []string) bool {
-	for _, rangeTag := range rangeTags {
+// replicaTagsAreSubsetOfNodeTags returns true iff a replica's tags are a subset of a node's tags
+func replicaTagsAreSubsetOfNodeTags(replicaTags []string, nodeTags []string) bool {
+	for _, replicaTag := range replicaTags {
 		foundMatch := false
 		for _, nodeTag := range nodeTags {
-			if rangeTag == nodeTag {
+			if replicaTag == nodeTag {
 				foundMatch = true
 				break
 			}
@@ -337,23 +186,23 @@ func rangeTagsAreSubsetOfNodeTags(rangeTags []string, nodeTags []string) bool {
 	return true
 }
 
-func (a *Allocator) adhereToChurnConstraint() {
-	if a.opts.prevAssignment == nil {
+func (a *allocator) adhereToChurnConstraint() {
+	if a.currentAssignment == nil {
 		panic("missing/invalid prior assignment")
 	}
 	toMinimizeTheSumLiterals := make([]solver.Literal, 0)
 	fixedDomain := solver.NewDomain(0, 0)
 
-	for _, r := range a.ranges {
-		// go over ranges, if a range was previously assigned to some node, attempt to keep that assignment as long as
+	for _, r := range a.replicas {
+		// go over replicas, if a replica was previously assigned to some node, attempt to keep that assignment as long as
 		// said node still exists in the cluster.
-		if prevNodeIDs, ok := a.opts.prevAssignment[r.id]; ok {
+		if prevNodeIDs, ok := a.currentAssignment[r.id]; ok {
 			for i, iv := range a.assignment[r.id] {
 				if _, ok := a.nodes[prevNodeIDs[i]]; ok {
-					newLiteral := a.model.NewLiteral(fmt.Sprintf("Literal tracking variance between assignment of range:%d, replica:%d on node:%d", r.id, i, prevNodeIDs[i]))
+					newLiteral := a.model.NewLiteral(fmt.Sprintf("Literal tracking variance between assignment of replica:%d, replica:%d on node:%d", r.id, i, prevNodeIDs[i]))
 					a.model.AddConstraints(
 						solver.NewLinearConstraint(
-							solver.NewLinearExpr([]solver.IntVar{iv, a.model.NewConstant(int64(prevNodeIDs[i]), fmt.Sprintf("IntVar corresponding to assignment of range:%d, replica:%d on node:%d", r.id, i, prevNodeIDs[i]))},
+							solver.NewLinearExpr([]solver.IntVar{iv, a.model.NewConstant(int64(prevNodeIDs[i]), fmt.Sprintf("IntVar corresponding to assignment of replica:%d, replica:%d on node:%d", r.id, i, prevNodeIDs[i]))},
 								[]int64{1, -1}, 0), fixedDomain).OnlyEnforceIf(newLiteral))
 					toMinimizeTheSumLiterals = append(toMinimizeTheSumLiterals, newLiteral.Not())
 				}
@@ -374,14 +223,13 @@ func (a *Allocator) adhereToChurnConstraint() {
 	}
 }
 
-// Allocate is a terminal method call that returns a status and paired allocation.
+// allocate is a terminal method call that returns a status and paired allocation.
 // The status could be false if the existing model is invalid or unsatisfiable.
-func (a *Allocator) Allocate(cluster Cluster, items Items) (ok bool, allocation Allocation) {
-	a.nodes = cluster.nodes
-	a.ranges = items.ranges
-	// iterate over ranges, assign each rangeID a list of IV's sized r.rf.
-	// These will ultimately then read as: rangeID's replicas assigned to nodes [N.1, N.2,...N.RF]
-	for _, r := range a.ranges {
+func (a *allocator) allocate() (ok bool, allocation Allocation) {
+
+	// iterate over replicas, assign each replicaID a list of IV's sized r.rf.
+	// These will ultimately then read as: replicaID's replicas assigned to nodes [N.1, N.2,...N.RF]
+	for _, r := range a.replicas {
 		a.assignment[r.id] = make([]solver.IntVar, r.rf)
 		for j := range a.assignment[r.id] {
 			// constrain our IV's to live between [0, len(nodes) - 1].
@@ -419,7 +267,7 @@ func (a *Allocator) Allocate(cluster Cluster, items Items) (ok bool, allocation 
 	}
 
 	res := make(Allocation)
-	for rID, r := range a.ranges {
+	for rID, r := range a.replicas {
 		nodes := a.assignment[rID]
 		for _, n := range nodes {
 			allocated := result.Value(n)

--- a/allocator_test.go
+++ b/allocator_test.go
@@ -236,22 +236,22 @@ func TestQPSandDiskBalancing(t *testing.T) {
 	}
 }
 
-func buildNodes(numNodes int64, nodeCapacities []int64, tags [][]string) allocator.NodeMap {
+func buildNodes(numNodes int64, nodeCapacities []int64, tags [][]string) allocator.ClusterNMap {
 	//nodes := make([]allocator.Node, numNodes)
-	nodes := make(allocator.NodeMap)
+	nodes := make(allocator.ClusterNMap)
 	var index int64
 	for index = 0; index < numNodes; index++ {
 		nodes.AddNode(
 			allocator.NodeID(index),
 			tags[index],
-			map[allocator.Resource]int64{allocator.DiskResource: nodeCapacities[index]},
+			nodeCapacities[index],
 			)
 	}
 	return nodes
 }
 
-func buildRanges(numRanges int64, rf int, demands []map[allocator.Resource]int64, tags [][]string) allocator.RangeMap {
-	rangesToAllocate := make(allocator.RangeMap)
+func buildRanges(numRanges int64, rf int, demands []map[allocator.Resource]int64, tags [][]string) allocator.ClusterRMap {
+	rangesToAllocate := make(allocator.ClusterRMap)
 	var index int64
 	for index = 0; index < numRanges; index++ {
 		rangesToAllocate.AddRange(

--- a/allocator_test.go
+++ b/allocator_test.go
@@ -11,9 +11,15 @@ func TestReplication(t *testing.T) {
 	const numRanges = 20
 	const rf = 3
 	const numNodes = 64
-	nodes := buildNodes(numNodes, nodeCapacitySupplier(numNodes, 0), buildEmptyTags(numNodes))
-	ranges := buildRanges(numRanges, rf, buildEmptyDemands(numRanges), buildEmptyTags(numRanges))
-	status, allocation := allocator.New(ranges, nodes).Allocate()
+	nodes := allocator.NewCluster()
+	for i := 0; i < numNodes; i++ {
+		nodes.AddNode(int64(i), 0)
+	}
+	ranges := allocator.NewItems()
+	for i := 0; i < numRanges; i++ {
+		ranges.AddRange(int64(i), rf, 0, 0)
+	}
+	status, allocation := allocator.New().Allocate(nodes, ranges)
 	require.True(t, status)
 	for _, nodeAssignments := range allocation {
 		require.Equal(t, len(nodeAssignments), rf)
@@ -28,9 +34,15 @@ func TestReplicationWithInsufficientNodes(t *testing.T) {
 	const numRanges = 20
 	const rf = 3
 	const numNodes = 1
-	nodes := buildNodes(numNodes, nodeCapacitySupplier(numNodes, 0), buildEmptyTags(numNodes))
-	ranges := buildRanges(numRanges, rf, buildEmptyDemands(numRanges), buildEmptyTags(numRanges))
-	status, allocation := allocator.New(ranges, nodes).Allocate()
+	nodes := allocator.NewCluster()
+	for i := 0; i < numNodes; i++ {
+		nodes.AddNode(int64(i), 0)
+	}
+	ranges := allocator.NewItems()
+	for i := 0; i < numRanges; i++ {
+		ranges.AddRange(int64(i), rf, 0, 0)
+	}
+	status, allocation := allocator.New().Allocate(nodes, ranges)
 	require.False(t, status)
 	require.Nil(t, allocation)
 }
@@ -40,9 +52,15 @@ func TestReplicationWithInfeasibleRF(t *testing.T) {
 	const numRanges = 20
 	const rf = 128
 	const numNodes = 64
-	nodes := buildNodes(numNodes, nodeCapacitySupplier(numNodes, 0), buildEmptyTags(numNodes))
-	ranges := buildRanges(numRanges, rf, buildEmptyDemands(numRanges), buildEmptyTags(numRanges))
-	status, allocation := allocator.New(ranges, nodes).Allocate()
+	nodes := allocator.NewCluster()
+	for i := 0; i < numNodes; i++ {
+		nodes.AddNode(int64(i), 0)
+	}
+	ranges := allocator.NewItems()
+	for i := 0; i < numRanges; i++ {
+		ranges.AddRange(int64(i), rf, 0, 0)
+	}
+	status, allocation := allocator.New().Allocate(nodes, ranges)
 	require.False(t, status)
 	require.Nil(t, allocation)
 }
@@ -52,13 +70,16 @@ func TestCapacity(t *testing.T) {
 	const numRanges = 20
 	const rf = 1
 	const numNodes = 8
-	nodes := buildNodes(numNodes, nodeCapacitySupplier(numNodes, 10_000), buildEmptyTags(numNodes))
-	rangeDemands := make([]map[allocator.Resource]int64, numRanges)
-	for i := range rangeDemands {
-		rangeDemands[i] = map[allocator.Resource]int64{allocator.DiskResource: int64(i)}
+	const nodeCapacity = 10_000
+	nodes := allocator.NewCluster()
+	for i := 0; i < numNodes; i++ {
+		nodes.AddNode(int64(i), nodeCapacity)
 	}
-	ranges := buildRanges(numRanges, rf, rangeDemands, buildEmptyTags(numRanges))
-	status, allocation := allocator.New(ranges, nodes, allocator.WithNodeCapacity()).Allocate()
+	ranges := allocator.NewItems()
+	for i := 0; i < numRanges; i++ {
+		ranges.AddRange(int64(i), rf, int64(i), 0)
+	}
+	status, allocation := allocator.New(allocator.WithNodeCapacity()).Allocate(nodes, ranges)
 	require.True(t, status)
 	for _, nodeAssignments := range allocation {
 		require.Equal(t, len(nodeAssignments), rf)
@@ -73,13 +94,15 @@ func TestCapacityTogetherWithReplication(t *testing.T) {
 	const numNodes = 3
 	clusterCapacities := []int64{90, 90, 90}
 	rangeSizeDemands := []int64{25, 10, 12, 11, 10}
-	rangeDemands := make([]map[allocator.Resource]int64, numRanges)
-	for i := range rangeDemands {
-		rangeDemands[i] = map[allocator.Resource]int64{allocator.DiskResource: rangeSizeDemands[i]}
+	nodes := allocator.NewCluster()
+	for i := 0; i < numNodes; i++ {
+		nodes.AddNode(int64(i), clusterCapacities[i])
 	}
-	nodes := buildNodes(numNodes, clusterCapacities, buildEmptyTags(numNodes))
-	ranges := buildRanges(numRanges, rf, rangeDemands, buildEmptyTags(numRanges))
-	status, allocation := allocator.New(ranges, nodes, allocator.WithNodeCapacity()).Allocate()
+	ranges := allocator.NewItems()
+	for i := 0; i < numRanges; i++ {
+		ranges.AddRange(int64(i), rf, rangeSizeDemands[i], 0)
+	}
+	status, allocation := allocator.New(allocator.WithNodeCapacity()).Allocate(nodes, ranges)
 	require.True(t, status)
 	for _, nodeAssignments := range allocation {
 		require.Equal(t, len(nodeAssignments), rf)
@@ -96,13 +119,15 @@ func TestCapacityWithInfeasibleRF(t *testing.T) {
 	const numNodes = 3
 	clusterCapacities := []int64{90, 90, 90}
 	rangeSizeDemands := []int64{25, 10, 12, 11, 10}
-	rangeDemands := make([]map[allocator.Resource]int64, numRanges)
-	for i := range rangeDemands {
-		rangeDemands[i] = map[allocator.Resource]int64{allocator.DiskResource: rangeSizeDemands[i]}
+	nodes := allocator.NewCluster()
+	for i := 0; i < numNodes; i++ {
+		nodes.AddNode(int64(i), clusterCapacities[i])
 	}
-	nodes := buildNodes(numNodes, clusterCapacities, buildEmptyTags(numNodes))
-	ranges := buildRanges(numRanges, rf, rangeDemands, buildEmptyTags(numRanges))
-	status, allocation := allocator.New(ranges, nodes, allocator.WithNodeCapacity()).Allocate()
+	ranges := allocator.NewItems()
+	for i := 0; i < numRanges; i++ {
+		ranges.AddRange(int64(i), rf, rangeSizeDemands[i], 0)
+	}
+	status, allocation := allocator.New(allocator.WithNodeCapacity()).Allocate(nodes, ranges)
 	require.False(t, status)
 	require.Nil(t, allocation)
 }
@@ -112,14 +137,17 @@ func TestCapacityWithInsufficientNodes(t *testing.T) {
 	const numRanges = 10
 	const rf = 1
 	const numNodes = 3
-	nodes := buildNodes(numNodes, []int64{70, 70, 70}, buildEmptyTags(numNodes))
+	clusterCapacities := []int64{70, 70, 70}
 	rangeSizeDemands := [numRanges]int64{85, 75, 12, 11, 10, 9, 8, 7, 6, 6}
-	rangeDemands := make([]map[allocator.Resource]int64, numRanges)
-	for i := range rangeDemands {
-		rangeDemands[i] = map[allocator.Resource]int64{allocator.DiskResource: rangeSizeDemands[i]}
+	nodes := allocator.NewCluster()
+	for i := 0; i < numNodes; i++ {
+		nodes.AddNode(int64(i), clusterCapacities[i])
 	}
-	ranges := buildRanges(numRanges, rf, rangeDemands, buildEmptyTags(numRanges))
-	status, allocation := allocator.New(ranges, nodes, allocator.WithNodeCapacity()).Allocate()
+	ranges := allocator.NewItems()
+	for i := 0; i < numRanges; i++ {
+		ranges.AddRange(int64(i), rf, rangeSizeDemands[i], 0)
+	}
+	status, allocation := allocator.New(allocator.WithNodeCapacity()).Allocate(nodes, ranges)
 	require.False(t, status)
 	require.Nil(t, allocation)
 }
@@ -139,14 +167,20 @@ func TestTagsWithViableNodes(t *testing.T) {
 		{"e=eat"},
 		{"a=ant", "b=bus"},
 	}
-	nodes := buildNodes(numNodes, nodeCapacitySupplier(numNodes, 0), nodeTags)
-	ranges := buildRanges(numRanges, rf, make([]map[allocator.Resource]int64, numRanges), rangeTags)
+	nodes := allocator.NewCluster()
+	for i := 0; i < numNodes; i++ {
+		nodes.AddNode(int64(i), 0, nodeTags[i]...)
+	}
+	ranges := allocator.NewItems()
+	for i := 0; i < numRanges; i++ {
+		ranges.AddRange(int64(i), rf, 0, 0, rangeTags[i]...)
+	}
 	expectedAllocation := allocator.Allocation{
 		0: {2},
 		1: {1},
 		2: {0},
 	}
-	status, allocation := allocator.New(ranges, nodes, allocator.WithTagMatching()).Allocate()
+	status, allocation := allocator.New(allocator.WithTagMatching()).Allocate(nodes, ranges)
 	require.True(t, status)
 	require.Equal(t, expectedAllocation, allocation)
 }
@@ -158,9 +192,15 @@ func TestTagsWithNonviableNodes(t *testing.T) {
 	const numNodes = 1
 	nodeTags := [][]string{{"tag=A"}}
 	rangeTags := [][]string{{"tag=B"}}
-	nodes := buildNodes(numNodes, nodeCapacitySupplier(numNodes, 0), nodeTags)
-	ranges := buildRanges(numRanges, rf, make([]map[allocator.Resource]int64, numRanges), rangeTags)
-	status, allocation := allocator.New(ranges, nodes, allocator.WithTagMatching()).Allocate()
+	nodes := allocator.NewCluster()
+	for i := 0; i < numNodes; i++ {
+		nodes.AddNode(int64(i), 0, nodeTags[i]...)
+	}
+	ranges := allocator.NewItems()
+	for i := 0; i < numRanges; i++ {
+		ranges.AddRange(int64(i), rf, 0, 0, rangeTags[i]...)
+	}
+	status, allocation := allocator.New(allocator.WithTagMatching()).Allocate(nodes, ranges)
 	require.False(t, status)
 	require.Nil(t, allocation)
 }
@@ -184,19 +224,23 @@ func TestMaxChurnWithInfeasibleLimit(t *testing.T) {
 		{"tag=A"},
 		{"tag=A"},
 	}
-	nodes := buildNodes(numNodes, nodeCapacitySupplier(numNodes, 0), nodeTags)
-	ranges := buildRanges(numRanges, rf, buildEmptyDemands(numRanges), rangeTags)
-	status, allocation := allocator.New(ranges, nodes, allocator.WithTagMatching()).Allocate()
+	nodes := allocator.NewCluster()
+	for i := 0; i < numNodes; i++ {
+		nodes.AddNode(int64(i), 0, nodeTags[i]...)
+	}
+	ranges := allocator.NewItems()
+	for i := 0; i < numRanges; i++ {
+		ranges.AddRange(int64(i), rf, 0, 0, rangeTags[i]...)
+	}
+	status, allocation := allocator.New(allocator.WithTagMatching()).Allocate(nodes, ranges)
 	require.True(t, status)
 
 	const maxChurn = 1
-	newTags:=buildEmptyTags(numNodes)
 	for index := 1; index < numNodes; index++ {
-	nodes.UpdateNodeTags(allocator.NodeID(index), newTags[index])
+		nodes.UpdateNodeTags(int64(index))
 	}
 
-	//badNodes := buildNodes(numNodes, nodeCapacitySupplier(numNodes, 0), buildEmptyTags(numNodes))
-	status, allocation = allocator.New(ranges, nodes, allocator.WithTagMatching(), allocator.WithChurnMinimized(), allocator.WithMaxChurn(maxChurn), allocator.WithPriorAssignment(allocation)).Allocate()
+	status, allocation = allocator.New(allocator.WithTagMatching(), allocator.WithChurnMinimized(), allocator.WithMaxChurn(maxChurn), allocator.WithPriorAssignment(allocation)).Allocate(nodes, ranges)
 	require.False(t, status)
 	require.Nil(t, allocation)
 }
@@ -207,17 +251,21 @@ func TestQPSandDiskBalancing(t *testing.T) {
 	const numRanges = 12
 	const rf = 1
 	const numNodes = 6
-	nodes := buildNodes(numNodes, nodeCapacitySupplier(numNodes, 10_000), buildEmptyTags(numNodes))
-	rangeDemands := make([]map[allocator.Resource]int64, numRanges)
+	const nodeCapacity = 10_000
 	sizeDemands := 0
 	qpsDemands := 0
-	for i := range rangeDemands {
-		rangeDemands[i] = map[allocator.Resource]int64{allocator.DiskResource: int64(i), allocator.Qps: int64(i)}
+
+	nodes := allocator.NewCluster()
+	for i := 0; i < numNodes; i++ {
+		nodes.AddNode(int64(i), nodeCapacity)
+	}
+	ranges := allocator.NewItems()
+	for i := 0; i < numRanges; i++ {
+		ranges.AddRange(int64(i), rf, int64(i), int64(i))
 		sizeDemands += i
 		qpsDemands += i
 	}
-	ranges := buildRanges(numRanges, rf, rangeDemands, buildEmptyTags(numRanges))
-	status, allocation := allocator.New(ranges, nodes, allocator.WithNodeCapacity()).Allocate()
+	status, allocation := allocator.New(allocator.WithNodeCapacity()).Allocate(nodes, ranges)
 	require.True(t, status)
 	reasonableVariance := 0.2
 	idealSizeAllocation := float64(sizeDemands+qpsDemands) / float64(numNodes)
@@ -225,7 +273,7 @@ func TestQPSandDiskBalancing(t *testing.T) {
 		require.Equal(t, len(nodeAssignments), rf)
 		require.True(t, isValidNodeAssignment(nodeAssignments, numNodes))
 	}
-	nodeConsumption := make(map[allocator.NodeID]int64)
+	nodeConsumption := make(map[int64]int64)
 	for rID, nodeAssignments := range allocation {
 		for _, nID := range nodeAssignments {
 			nodeConsumption[nID] += 2 * int64(rID)
@@ -236,52 +284,17 @@ func TestQPSandDiskBalancing(t *testing.T) {
 	}
 }
 
-func buildNodes(numNodes int64, nodeCapacities []int64, tags [][]string) allocator.ClusterNMap {
-	//nodes := make([]allocator.Node, numNodes)
-	nodes := make(allocator.ClusterNMap)
-	var index int64
-	for index = 0; index < numNodes; index++ {
-		nodes.AddNode(
-			allocator.NodeID(index),
-			tags[index],
-			nodeCapacities[index],
-			)
-	}
-	return nodes
-}
-
-func buildRanges(numRanges int64, rf int, demands []map[allocator.Resource]int64, tags [][]string) allocator.ClusterRMap {
-	rangesToAllocate := make(allocator.ClusterRMap)
-	var index int64
-	for index = 0; index < numRanges; index++ {
-		rangesToAllocate.AddRange(
-			allocator.RangeID(index),
-			rf,
-			tags[index],
-			demands[index])
-	}
-	return rangesToAllocate
-}
-
-func nodeCapacitySupplier(clusterSize int64, capacity int64) []int64 {
-	nodeCapacities := make([]int64, clusterSize)
-	for index := 0; index < len(nodeCapacities); index++ {
-		nodeCapacities[index] = capacity
-	}
-	return nodeCapacities
-}
-
-func isValidNodeAssignment(nodeIDs []allocator.NodeID, clusterSize int64) bool {
+func isValidNodeAssignment(nodeIDs []int64, clusterSize int64) bool {
 	for _, nodeID := range nodeIDs {
-		if nodeID < 0 || int64(nodeID) > clusterSize {
+		if nodeID < 0 || nodeID > clusterSize {
 			return false
 		}
 	}
 	return true
 }
 
-func isEachReplicaAssignedToDifferentNode(nodeIDs []allocator.NodeID) bool {
-	nodeIdSet := make(map[allocator.NodeID]struct{})
+func isEachReplicaAssignedToDifferentNode(nodeIDs []int64) bool {
+	nodeIdSet := make(map[int64]struct{})
 	for _, nodeID := range nodeIDs {
 		if _, found := nodeIdSet[nodeID]; found {
 			return false
@@ -292,8 +305,8 @@ func isEachReplicaAssignedToDifferentNode(nodeIDs []allocator.NodeID) bool {
 	return true
 }
 
-func nodeCapacityIsRespected(allocation map[allocator.RangeID][]allocator.NodeID, nodeCapacities []int64, rangeDemands []int64) bool {
-	inUseCapacity := make(map[allocator.NodeID]int64)
+func nodeCapacityIsRespected(allocation map[int64][]int64, nodeCapacities []int64, rangeDemands []int64) bool {
+	inUseCapacity := make(map[int64]int64)
 	for rangeID, nodeAssignments := range allocation {
 		for _, node := range nodeAssignments {
 			inUseCapacity[node] += rangeDemands[rangeID]
@@ -305,20 +318,4 @@ func nodeCapacityIsRespected(allocation map[allocator.RangeID][]allocator.NodeID
 		}
 	}
 	return true
-}
-
-func buildEmptyTags(len int) [][]string {
-	ret := make([][]string, len)
-	for i := range ret {
-		ret[i] = make([]string, 0)
-	}
-	return ret
-}
-
-func buildEmptyDemands(len int) []map[allocator.Resource]int64 {
-	ret := make([]map[allocator.Resource]int64, len)
-	for i := range ret {
-		ret[i] = make(map[allocator.Resource]int64)
-	}
-	return ret
 }

--- a/cluster.go
+++ b/cluster.go
@@ -15,13 +15,11 @@ type ClusterState struct {
 }
 
 func NewClusterState() *ClusterState {
-	clusterState := &ClusterState{
+	return &ClusterState{
 		nodes:             make(map[nodeId]*node),
 		replicas:          make(map[replicaId]*replica),
 		currentAssignment: make(map[replicaId][]nodeId),
 	}
-
-	return clusterState
 }
 
 // AddReplica will add or overwrite the existing replica given an ID

--- a/cluster.go
+++ b/cluster.go
@@ -1,0 +1,95 @@
+package allocator
+
+// Resource is 32-bit identifier for resources -> {disk, QPS}
+type Resource int
+
+const (
+	DiskResource Resource = iota
+	QPS
+)
+
+type ClusterState struct {
+	nodes             map[nodeId]*node
+	replicas          map[replicaId]*replica
+	currentAssignment map[replicaId][]nodeId
+}
+
+func NewClusterState() *ClusterState {
+	clusterState := &ClusterState{
+		nodes:             make(map[nodeId]*node),
+		replicas:          make(map[replicaId]*replica),
+		currentAssignment: make(map[replicaId][]nodeId),
+	}
+
+	return clusterState
+}
+
+// AddReplica will add or overwrite the existing replica given an ID
+func (cs *ClusterState) AddReplica(id int64, rf int, opts ...ReplicaOption) {
+	newReplica := newReplica(replicaId(id), rf)
+	for _, opt := range opts {
+		opt(newReplica)
+	}
+	cs.replicas[replicaId(id)] = newReplica
+}
+
+// RemoveReplica removes a given replica from the cluster
+// no-op if it doesn't exist.
+func (cs *ClusterState) RemoveReplica(id int64) {
+	delete(cs.replicas, replicaId(id))
+}
+
+// UpdateReplica will update the existing replica given an ID
+// returning true for a successful update, false if the replicaID does not map to any replica.
+func (cs *ClusterState) UpdateReplica(id int64, opts ...ReplicaOption) bool {
+	if modifiedReplicaPtr, found := cs.replicas[replicaId(id)]; found {
+		for _, opt := range opts {
+			opt(modifiedReplicaPtr)
+		}
+		cs.replicas[replicaId(id)] = modifiedReplicaPtr
+
+		return true
+	}
+	return false
+}
+
+// AddNode will add or overwrite the existing node given an ID
+func (cs *ClusterState) AddNode(id int64, opts ...NodeOption) {
+	newNode := newNode(nodeId(id))
+	for _, opt := range opts {
+		opt(newNode)
+	}
+	cs.nodes[nodeId(id)] = newNode
+}
+
+// RemoveNode removes a given node from the cluster
+// no-op if it doesn't exist.
+func (cs *ClusterState) RemoveNode(id int64) {
+	delete(cs.nodes, nodeId(id))
+}
+
+// UpdateNode will update the existing node given an ID
+// returning true for a successful update, false if the nodeID does not map to any node.
+func (cs *ClusterState) UpdateNode(id int64, opts ...NodeOption) bool {
+	if modifiedNodePtr, found := cs.nodes[nodeId(id)]; found {
+		for _, opt := range opts {
+			opt(modifiedNodePtr)
+		}
+		cs.nodes[nodeId(id)] = modifiedNodePtr
+
+		return true
+	}
+	return false
+}
+
+// UpdateCurrentAssignment store the current allocation state to potentially guide the solver
+func (cs *ClusterState) UpdateCurrentAssignment(priorAllocation Allocation) {
+	temp := make(map[replicaId][]nodeId)
+	for r, n := range priorAllocation {
+		temp[replicaId(r)] = make([]nodeId, len(n))
+		for nid := range n {
+			temp[replicaId(r)] = append(temp[replicaId(r)], nodeId(nid))
+		}
+	}
+	cs.currentAssignment = temp
+}

--- a/cluster.go
+++ b/cluster.go
@@ -87,8 +87,8 @@ func (cs *ClusterState) UpdateCurrentAssignment(priorAllocation Allocation) {
 	temp := make(map[replicaId][]nodeId)
 	for r, n := range priorAllocation {
 		temp[replicaId(r)] = make([]nodeId, len(n))
-		for nid := range n {
-			temp[replicaId(r)] = append(temp[replicaId(r)], nodeId(nid))
+		for i, nid := range n {
+			temp[replicaId(r)][i] = nodeId(nid)
 		}
 	}
 	cs.currentAssignment = temp

--- a/go.sum
+++ b/go.sum
@@ -185,6 +185,10 @@ github.com/hydrogen18/memlistener v0.0.0-20141126152155-54553eb933fb/go.mod h1:q
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
+github.com/irfansharif/allocator v0.0.0-20210807031756-96fda6c95716 h1:T/EaBUtccHVFTpnwX63qzIaBABfnOhZbCFYseyRIzhM=
+github.com/irfansharif/allocator v0.0.0-20210807031756-96fda6c95716/go.mod h1:V+ekc19OeFYTKni/hHRJniHTNg6sACfmdKP3npD/vvc=
+github.com/irfansharif/or-tools v0.0.0-20210806150710-7bf371607f5d h1:m/iQkO+XU8XYoozqrHTdDufMkCzRJzuQWZIt0QVZWAM=
+github.com/irfansharif/or-tools v0.0.0-20210806150710-7bf371607f5d/go.mod h1:R/dumbSyTGDtltABqk8bHM3YHisdUCW46mEc1eSqCkY=
 github.com/irfansharif/solver v0.0.0-20211002024421-11071354d9bd h1:KFwYhOTlzh8jXabSVs0MWZhoarPOPnEG+YutvnCX0QI=
 github.com/irfansharif/solver v0.0.0-20211002024421-11071354d9bd/go.mod h1:otW5LRFN5Lkiw+vFz5YVn+ON/A1wH6aHgKZ5901KCFY=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=

--- a/go.sum
+++ b/go.sum
@@ -185,10 +185,6 @@ github.com/hydrogen18/memlistener v0.0.0-20141126152155-54553eb933fb/go.mod h1:q
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/irfansharif/allocator v0.0.0-20210807031756-96fda6c95716 h1:T/EaBUtccHVFTpnwX63qzIaBABfnOhZbCFYseyRIzhM=
-github.com/irfansharif/allocator v0.0.0-20210807031756-96fda6c95716/go.mod h1:V+ekc19OeFYTKni/hHRJniHTNg6sACfmdKP3npD/vvc=
-github.com/irfansharif/or-tools v0.0.0-20210806150710-7bf371607f5d h1:m/iQkO+XU8XYoozqrHTdDufMkCzRJzuQWZIt0QVZWAM=
-github.com/irfansharif/or-tools v0.0.0-20210806150710-7bf371607f5d/go.mod h1:R/dumbSyTGDtltABqk8bHM3YHisdUCW46mEc1eSqCkY=
 github.com/irfansharif/solver v0.0.0-20211002024421-11071354d9bd h1:KFwYhOTlzh8jXabSVs0MWZhoarPOPnEG+YutvnCX0QI=
 github.com/irfansharif/solver v0.0.0-20211002024421-11071354d9bd/go.mod h1:otW5LRFN5Lkiw+vFz5YVn+ON/A1wH6aHgKZ5901KCFY=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=

--- a/node.go
+++ b/node.go
@@ -16,7 +16,7 @@ type node struct {
 func newNode(id nodeId) *node {
 	return &node{
 		id:        id,
-		resources: make(map[Resource]int64), // To avoid SegFault
+		resources: make(map[Resource]int64),
 	}
 }
 

--- a/node.go
+++ b/node.go
@@ -1,0 +1,52 @@
+package allocator
+
+// nodeId is a 64-bit identifier for nodes.
+type nodeId int64
+
+// node encapsulates pertaining metadata for cockroachDB nodes.
+type node struct {
+	// id represents a unique identifier.
+	id nodeId
+	// tags are strings that showcase affinity for replicas.
+	tags []string
+	// resources model the Resource profile of said node.
+	resources map[Resource]int64
+}
+
+func newNode(id nodeId) *node {
+	return &node{
+		id:        id,
+		resources: make(map[Resource]int64), // To avoid SegFault
+	}
+}
+
+type NodeOption func(*node)
+
+// WithTagsOfNode replaces tags of a node
+func WithTagsOfNode(tags ...string) NodeOption {
+	return func(modifiedNode *node) {
+		modifiedNode.tags = tags
+	}
+}
+
+// AddTagsToNode add tags to a node
+// Note it does not check for uniqueness, perhaps we should change tags to a unique set instead of a slice
+func AddTagsToNode(tags ...string) NodeOption {
+	return func(modifiedNode *node) {
+		modifiedNode.tags = append(modifiedNode.tags, tags...)
+	}
+}
+
+// RemoveAllTagsOfNode will remove all tags of a node
+func RemoveAllTagsOfNode() NodeOption {
+	return func(modifiedNode *node) {
+		modifiedNode.tags = nil
+	}
+}
+
+// WithResourceOfNode will add or overwrite the amount of a target Resource the node provides
+func WithResourceOfNode(targetResource Resource, resourceAmount int64) NodeOption {
+	return func(modifiedNode *node) {
+		modifiedNode.resources[targetResource] = resourceAmount
+	}
+}

--- a/replica.go
+++ b/replica.go
@@ -1,0 +1,62 @@
+package allocator
+
+// replicaId is a 64-bit identifier for replicas.
+type replicaId int64
+
+// replica encapsulates pertaining metadata for cockroachDB replicas.
+type replica struct {
+	// id represents a unique identifier.
+	id replicaId
+	// rf equals the replication factor of said replica.
+	rf int
+	// tags are strings that showcase affinity for replicas.
+	tags []string
+	// demands model the Resource requirements of said replica.
+	demands map[Resource]int64
+}
+
+func newReplica(id replicaId, rf int) *replica {
+	return &replica{
+		id:      id,
+		rf:      rf,
+		demands: make(map[Resource]int64), // To avoid SegFault
+	}
+}
+
+type ReplicaOption func(*replica)
+
+// WithReplicationFactorOfReplica updates replication factor of a replica
+func WithReplicationFactorOfReplica(replicationFactor int) ReplicaOption {
+	return func(modifiedReplica *replica) {
+		modifiedReplica.rf = replicationFactor
+	}
+}
+
+// WithTagsOfReplica replaces tags of a replica
+func WithTagsOfReplica(tags ...string) ReplicaOption {
+	return func(modifiedReplica *replica) {
+		modifiedReplica.tags = tags
+	}
+}
+
+// AddTagsToReplica add tags to a replica
+// Note it does not check for uniqueness, perhaps we should change tags to a unique set instead of a slice
+func AddTagsToReplica(tags ...string) ReplicaOption {
+	return func(modifiedReplica *replica) {
+		modifiedReplica.tags = append(modifiedReplica.tags, tags...)
+	}
+}
+
+// RemoveAllTagsOfReplica will remove all tags of a replica
+func RemoveAllTagsOfReplica() ReplicaOption {
+	return func(modifiedReplica *replica) {
+		modifiedReplica.tags = nil
+	}
+}
+
+// WithDemandOfReplica will add or overwrite the amount of a target Resource the replica demands
+func WithDemandOfReplica(targetResource Resource, demandAmount int64) ReplicaOption {
+	return func(modifiedReplica *replica) {
+		modifiedReplica.demands[targetResource] = demandAmount
+	}
+}

--- a/replica.go
+++ b/replica.go
@@ -19,7 +19,7 @@ func newReplica(id replicaId, rf int) *replica {
 	return &replica{
 		id:      id,
 		rf:      rf,
-		demands: make(map[Resource]int64), // To avoid SegFault
+		demands: make(map[Resource]int64),
 	}
 }
 


### PR DESCRIPTION
Break objects to separate files 
Streamline interface usage with options pattern
Modify interfaces to avoid misuse of the the allocator