### PR TITLE
[MaxChurn] Fix composition bug.

### DIFF
--- a/allocator.go
+++ b/allocator.go
@@ -235,8 +235,8 @@ func WithPriorAssignment(prevAssignment map[int64][]int64) Option {
 	temp := make(map[rangeId][]nodeId)
 	for r, n := range prevAssignment {
 		temp[rangeId(r)] = make([]nodeId, len(n))
-		for nid := range n {
-			temp[rangeId(r)] = append(temp[rangeId(r)], nodeId(nid))
+		for i, nid := range n {
+			temp[rangeId(r)][i] = nodeId(nid)
 		}
 	}
 	return func(opt *options) {


### PR DESCRIPTION
PR to fix a small bug in slice composition. The slice was built using `temp[rangeId(r)] = make([]nodeId, len(n))`, assuming a `len(n)` equalling `3`, the prior implementation resulted in a list built as `[0 0 0 0 1 2]` for prior assignments of `[0 1 2]`. This PR rectifies the above by directly indexing instead of appending.