### PR TITLE
[Tagging] Add missing comment, missing space, and convert tag fields into sets.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -9,7 +9,7 @@ gazelle(
 
 go_library(
     name = "allocator",
-    srcs = ["allocator.go","allocOptions.go", "cluster.go", "node.go", "replica.go"],
+    srcs = ["allocator.go", "allocOptions.go", "cluster.go", "node.go", "replica.go"],
     importpath = "github.com/smcheema/allocator",
     visibility = ["//visibility:public"],
     deps = ["@com_github_irfansharif_solver//:solver"],

--- a/allocator.go
+++ b/allocator.go
@@ -13,6 +13,7 @@ type Allocation map[int64][]int64
 
 // allocator holds the replicas, nodes, underlying CP-SAT solver, assigment variables, and configuration needed.
 type allocator struct {
+	// ClusterState anonymous type that holds our ranges and nodes metadata.
 	*ClusterState
 	// model is the underlying CP-SAT solver and the engine of this package.
 	model *solver.Model
@@ -119,16 +120,9 @@ func (a *allocator) adhereToNodeTags() {
 }
 
 // replicaTagsAreSubsetOfNodeTags returns true iff a replica's tags are a subset of a node's tags
-func replicaTagsAreSubsetOfNodeTags(replicaTags []string, nodeTags []string) bool {
-	for _, replicaTag := range replicaTags {
-		foundMatch := false
-		for _, nodeTag := range nodeTags {
-			if replicaTag == nodeTag {
-				foundMatch = true
-				break
-			}
-		}
-		if !foundMatch {
+func replicaTagsAreSubsetOfNodeTags(replicaTags map[string]struct{}, nodeTags map[string]struct{}) bool {
+	for replicaTag := range replicaTags {
+		if _, found := nodeTags[replicaTag]; !found {
 			return false
 		}
 	}

--- a/node.go
+++ b/node.go
@@ -8,6 +8,10 @@ type node struct {
 	// id represents a unique identifier.
 	id nodeId
 	// tags are strings that showcase affinity for replicas.
+	// note: we key the following map using the tag,
+	// and assign an empty struct as the corresponding value,
+	// since we only care about tag membership,
+	// and not values assigned to said tag per se.
 	tags map[string]struct{}
 	// resources model the Resource profile of said node.
 	resources map[Resource]int64
@@ -37,6 +41,7 @@ func WithTagsOfNode(tags ...string) NodeOption {
 func AddTagsToNode(tags ...string) NodeOption {
 	return func(modifiedNode *node) {
 		for _, tag := range tags {
+			// build empty struct, really a placeholder value to satisfy map semantics
 			modifiedNode.tags[tag] = struct{}{}
 		}
 	}

--- a/node.go
+++ b/node.go
@@ -8,7 +8,7 @@ type node struct {
 	// id represents a unique identifier.
 	id nodeId
 	// tags are strings that showcase affinity for replicas.
-	tags []string
+	tags map[string]struct{}
 	// resources model the Resource profile of said node.
 	resources map[Resource]int64
 }
@@ -25,7 +25,11 @@ type NodeOption func(*node)
 // WithTagsOfNode replaces tags of a node
 func WithTagsOfNode(tags ...string) NodeOption {
 	return func(modifiedNode *node) {
-		modifiedNode.tags = tags
+		tagsM := make(map[string]struct{})
+		for _, tag := range tags {
+			tagsM[tag] = struct{}{}
+		}
+		modifiedNode.tags = tagsM
 	}
 }
 
@@ -33,7 +37,9 @@ func WithTagsOfNode(tags ...string) NodeOption {
 // Note it does not check for uniqueness, perhaps we should change tags to a unique set instead of a slice
 func AddTagsToNode(tags ...string) NodeOption {
 	return func(modifiedNode *node) {
-		modifiedNode.tags = append(modifiedNode.tags, tags...)
+		for _, tag := range tags {
+			modifiedNode.tags[tag] = struct{}{}
+		}
 	}
 }
 

--- a/node.go
+++ b/node.go
@@ -8,9 +8,9 @@ type node struct {
 	// id represents a unique identifier.
 	id nodeId
 	// tags are strings that showcase affinity for replicas.
-	// note: we key the following map using the tag,
-	// and assign an empty struct as the corresponding value,
-	// since we only care about tag membership,
+	// note: we key the following map using the tag
+	// and assign an empty struct as the corresponding value
+	// since we only care about tag membership
 	// and not values assigned to said tag per se.
 	tags map[string]struct{}
 	// resources model the Resource profile of said node.

--- a/node.go
+++ b/node.go
@@ -34,7 +34,6 @@ func WithTagsOfNode(tags ...string) NodeOption {
 }
 
 // AddTagsToNode add tags to a node
-// Note it does not check for uniqueness, perhaps we should change tags to a unique set instead of a slice
 func AddTagsToNode(tags ...string) NodeOption {
 	return func(modifiedNode *node) {
 		for _, tag := range tags {

--- a/replica.go
+++ b/replica.go
@@ -10,9 +10,9 @@ type replica struct {
 	// rf equals the replication factor of said replica.
 	rf int
 	// tags are strings that showcase affinity for replicas.
-	// note: we key the following map using the tag,
-	// and assign an empty struct as the corresponding value,
-	// since we only care about tag membership,
+	// note: we key the following map using the tag
+	// and assign an empty struct as the corresponding value
+	// since we only care about tag membership
 	// and not values assigned to said tag per se.
 	tags map[string]struct{}
 	// demands model the Resource requirements of said replica.

--- a/replica.go
+++ b/replica.go
@@ -10,7 +10,7 @@ type replica struct {
 	// rf equals the replication factor of said replica.
 	rf int
 	// tags are strings that showcase affinity for replicas.
-	tags []string
+	tags map[string]struct{}
 	// demands model the Resource requirements of said replica.
 	demands map[Resource]int64
 }
@@ -35,7 +35,11 @@ func WithReplicationFactorOfReplica(replicationFactor int) ReplicaOption {
 // WithTagsOfReplica replaces tags of a replica
 func WithTagsOfReplica(tags ...string) ReplicaOption {
 	return func(modifiedReplica *replica) {
-		modifiedReplica.tags = tags
+		tagsM := make(map[string]struct{})
+		for _, tag := range tags {
+			tagsM[tag] = struct{}{}
+		}
+		modifiedReplica.tags = tagsM
 	}
 }
 
@@ -43,7 +47,9 @@ func WithTagsOfReplica(tags ...string) ReplicaOption {
 // Note it does not check for uniqueness, perhaps we should change tags to a unique set instead of a slice
 func AddTagsToReplica(tags ...string) ReplicaOption {
 	return func(modifiedReplica *replica) {
-		modifiedReplica.tags = append(modifiedReplica.tags, tags...)
+		for _, tag := range tags {
+			modifiedReplica.tags[tag] = struct{}{}
+		}
 	}
 }
 

--- a/replica.go
+++ b/replica.go
@@ -44,7 +44,6 @@ func WithTagsOfReplica(tags ...string) ReplicaOption {
 }
 
 // AddTagsToReplica add tags to a replica
-// Note it does not check for uniqueness, perhaps we should change tags to a unique set instead of a slice
 func AddTagsToReplica(tags ...string) ReplicaOption {
 	return func(modifiedReplica *replica) {
 		for _, tag := range tags {

--- a/replica.go
+++ b/replica.go
@@ -10,6 +10,10 @@ type replica struct {
 	// rf equals the replication factor of said replica.
 	rf int
 	// tags are strings that showcase affinity for replicas.
+	// note: we key the following map using the tag,
+	// and assign an empty struct as the corresponding value,
+	// since we only care about tag membership,
+	// and not values assigned to said tag per se.
 	tags map[string]struct{}
 	// demands model the Resource requirements of said replica.
 	demands map[Resource]int64
@@ -47,6 +51,7 @@ func WithTagsOfReplica(tags ...string) ReplicaOption {
 func AddTagsToReplica(tags ...string) ReplicaOption {
 	return func(modifiedReplica *replica) {
 		for _, tag := range tags {
+			// build empty struct, really a placeholder value to satisfy map semantics
 			modifiedReplica.tags[tag] = struct{}{}
 		}
 	}


### PR DESCRIPTION
We use tags solely for membership testing, hence it makes sense to internally represent them using `Sets`. This makes some of the error handling work for the `tag` constraint less clunky and verbose.