### PR TITLE
[Misc] Make RF a global property.

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -23,13 +23,11 @@ func NewClusterState() *ClusterState {
 }
 
 // AddShard will add or overwrite the existing shard given a shardId
-func (cs *ClusterState) AddShard(id int64, rf int, opts ...ShardOption) {
+func (cs *ClusterState) AddShard(id int64, opts ...ShardOption) {
 	if id < 0 {
 		panic("shard id cannot be negative")
-	} else if rf < 0 {
-		panic("shard rf cannot be negative")
 	}
-	s := newShard(shardId(id), rf)
+	s := newShard(shardId(id))
 	for _, opt := range opts {
 		opt(s)
 	}

--- a/configuration.go
+++ b/configuration.go
@@ -6,6 +6,7 @@ const (
 	noMaxChurn     = -1
 	defaultTimeout = time.Second * 10
 	loggingPrefix  = ""
+	defaultRf      = 3
 )
 
 // Configuration holds runtime allocation preferences.
@@ -22,6 +23,8 @@ type Configuration struct {
 	searchTimeout time.Duration
 	// verboseLogging routes all the internal solver logs to stdout.
 	verboseLogging bool
+	// rf specifies the replication factor applied to all shards.
+	rf int
 }
 
 // ConfigurationOption manifests a closure that mutates allocation configurations in accordance with caller preferences.
@@ -32,6 +35,7 @@ func NewConfiguration(opts ...ConfigurationOption) *Configuration {
 		// assume no maxChurn initially, let the opts slice override if needed.
 		maxChurn:      noMaxChurn,
 		searchTimeout: defaultTimeout,
+		rf:            defaultRf,
 	}
 	for _, opt := range opts {
 		opt(&defaultConfiguration)
@@ -99,5 +103,15 @@ func WithTimeout(searchTimeout time.Duration) ConfigurationOption {
 func WithVerboseLogging(enable bool) ConfigurationOption {
 	return func(opt *Configuration) {
 		opt.verboseLogging = enable
+	}
+}
+
+// WithReplicationFactor is a closure that overrides our default replication factor of 3.
+func WithReplicationFactor(rf int) ConfigurationOption {
+	return func(opt *Configuration) {
+		if rf < 0 {
+			panic("rf cannot be negative")
+		}
+		opt.rf = rf
 	}
 }

--- a/shard.go
+++ b/shard.go
@@ -7,8 +7,6 @@ type shardId int64
 type shard struct {
 	// id represents a unique identifier.
 	id shardId
-	// rf equals the replication factor of said shard.
-	rf int
 	// tags are strings that showcase affinity for shards.
 	// note: we key the following map using the tag
 	// and assign an empty struct as the corresponding value
@@ -19,22 +17,14 @@ type shard struct {
 	demands map[Resource]int64
 }
 
-func newShard(id shardId, rf int) *shard {
+func newShard(id shardId) *shard {
 	return &shard{
 		id:      id,
-		rf:      rf,
 		demands: make(map[Resource]int64),
 	}
 }
 
 type ShardOption func(*shard)
-
-// WithReplicationFactor updates the replication factor of a shard
-func WithReplicationFactor(replicationFactor int) ShardOption {
-	return func(s *shard) {
-		s.rf = replicationFactor
-	}
-}
 
 // WithTagsOfShard replaces tags of a shard
 func WithTagsOfShard(tags ...string) ShardOption {


### PR DESCRIPTION
All of our tests assume a uniform replication factor across shards. This PR implements it. `RF` is now defaulted at `3`, with the option to override. 